### PR TITLE
Re-export strum to allow external use EnumIter impls for projects using Strum

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -40,7 +40,7 @@
 //! // returns a Vector of the Notes of the chord
 //! let chord_notes = chord.notes();
 
-extern crate strum;
+pub extern crate strum;
 pub mod chord;
 pub mod interval;
 pub mod note;


### PR DESCRIPTION
Made strum pub so that projects using this crate and strum don't have issues with two copies of strum in the dependency graph.