### PR TITLE
Prepare v0.4.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,22 @@
+## v0.4.0 - 2026-07-12
+
+### Features
+- Add MIDI file export for notes, chords, scales, tracks, tempo, and time signatures
+- Add optional real-time MIDI playback, port discovery, program changes, control changes, and MIDI clock
+- Add Minor Ninth chord support and conventional compact chord symbols such as `C7`, `Cmaj7`, and `Cm7`
+- Add fallible chord construction APIs and runnable Node/WASM tests
+
+### Fixes
+- Preserve written interval and chord spelling, including flats and double accidentals
+- Correct chord extensions, slash bass notes, invalid-input handling, and inversion validation
+- Correct classical melodic-minor descent, blues and chromatic spelling, and modal key signatures
+- Prevent octave underflow during descending transposition
+- Mark MIDI playback examples with their required Cargo feature
+
+### Breaking Changes
+- Change public note, chord, scale, and WASM octave values from `u8` to `i16`
+- Reject unsupported chord quality and number combinations instead of silently producing a major triad
+
 ## v0.2.0 - 2020-08-19
 
 ### Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rust-music-theory"
 description = "A library that procedurally implements music theory notions like Scale, Chord, Interval, Note"
 license = "MIT"
-version = "0.3.0"
+version = "0.4.0"
 readme = "README.md"
 repository = "https://github.com/ozankasikci/rust-music-theory"
 authors = ["Ozan Kaşıkçı <ozan@kasikci.io>"]
@@ -17,6 +17,34 @@ midi-playback = ["midi", "dep:midir"]
 
 [lib]
 crate-type = ["cdylib", "rlib"]
+
+[[example]]
+name = "hypnotic_techno"
+required-features = ["midi-playback"]
+
+[[example]]
+name = "midi_cc_demo"
+required-features = ["midi-playback"]
+
+[[example]]
+name = "nocturne"
+required-features = ["midi-playback"]
+
+[[example]]
+name = "nocturne_duo"
+required-features = ["midi-playback"]
+
+[[example]]
+name = "simple_midi_test"
+required-features = ["midi-playback"]
+
+[[example]]
+name = "synth_chords"
+required-features = ["midi-playback"]
+
+[[example]]
+name = "techno_bass"
+required-features = ["midi-playback"]
 
 [dependencies]
 strum = "0.17.1"

--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ Enable the `midi` feature to export chords and scales to MIDI files:
 
 ```toml
 [dependencies]
-rust-music-theory = { version = "0.3", features = ["midi"] }
+rust-music-theory = { version = "0.4", features = ["midi"] }
 ```
 
 ```rust
@@ -101,7 +101,7 @@ Enable the `midi-playback` feature to play notes on connected MIDI devices (hard
 
 ```toml
 [dependencies]
-rust-music-theory = { version = "0.3", features = ["midi-playback"] }
+rust-music-theory = { version = "0.4", features = ["midi-playback"] }
 ```
 
 ```rust

--- a/examples/hypnotic_techno.rs
+++ b/examples/hypnotic_techno.rs
@@ -1,9 +1,6 @@
 //! Hypnotic techno bass with MIDI CC automation.
 //! Run with: cargo run --example hypnotic_techno --features midi-playback
 
-use std::thread;
-use std::time::Duration;
-
 use rust_music_theory::midi::playback::{MidiPorts, MidiPlayer};
 use rust_music_theory::midi::{Duration as NoteDuration, Velocity};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -46,7 +46,7 @@
 //! With the `midi` feature enabled, you can export chords and scales to MIDI files:
 //!
 //! ```toml
-//! rust-music-theory = { version = "0.3", features = ["midi"] }
+//! rust-music-theory = { version = "0.4", features = ["midi"] }
 //! ```
 //!
 //! ```ignore
@@ -61,7 +61,7 @@
 //! With the `midi-playback` feature, play to connected MIDI instruments:
 //!
 //! ```toml
-//! rust-music-theory = { version = "0.3", features = ["midi-playback"] }
+//! rust-music-theory = { version = "0.4", features = ["midi-playback"] }
 //! ```
 //!
 //! ```ignore

--- a/src/midi.rs
+++ b/src/midi.rs
@@ -7,7 +7,7 @@
 //!
 //! Enable with the `midi` feature flag:
 //! ```toml
-//! rust-music-theory = { version = "0.3", features = ["midi"] }
+//! rust-music-theory = { version = "0.4", features = ["midi"] }
 //! ```
 //!
 //! # Quick Export
@@ -60,7 +60,7 @@
 //! With the `midi-playback` feature, you can play notes on connected MIDI devices:
 //!
 //! ```toml
-//! rust-music-theory = { version = "0.3", features = ["midi-playback"] }
+//! rust-music-theory = { version = "0.4", features = ["midi-playback"] }
 //! ```
 //!
 //! ```ignore

--- a/tests/midi_integration.rs
+++ b/tests/midi_integration.rs
@@ -58,17 +58,19 @@ fn simple_chord_export() {
 
 #[test]
 fn all_chord_qualities() {
-    let qualities = [
-        Quality::Major,
-        Quality::Minor,
-        Quality::Diminished,
-        Quality::Augmented,
-        Quality::HalfDiminished,
-        Quality::Dominant,
+    let chords = [
+        (Quality::Major, Number::Triad),
+        (Quality::Minor, Number::Triad),
+        (Quality::Diminished, Number::Triad),
+        (Quality::Augmented, Number::Triad),
+        (Quality::HalfDiminished, Number::Seventh),
+        (Quality::Dominant, Number::Seventh),
+        (Quality::Suspended2, Number::Triad),
+        (Quality::Suspended4, Number::Triad),
     ];
 
-    for quality in qualities {
-        let chord = Chord::new(Pitch::from(C), quality, Number::Triad);
+    for (quality, number) in chords {
+        let chord = Chord::new(Pitch::from(C), quality, number);
         let bytes = chord.to_midi(Duration::Quarter, Velocity::new(100).unwrap())
             .to_bytes();
         assert_eq!(&bytes[0..4], b"MThd", "Failed for quality {:?}", quality);


### PR DESCRIPTION
## What changed

- bump the crate version to `0.4.0`
- update README and Rustdoc dependency examples to `0.4`
- add the v0.4.0 changelog covering MIDI features, theory correctness fixes, and breaking changes
- declare `midi-playback` as required for all playback examples so default-feature builds do not compile unavailable APIs
- correct MIDI integration coverage to pair every chord quality with a supported chord number
- remove unused imports from the hypnotic techno example

## Why

Version 0.4.0 is the appropriate pre-1.0 SemVer bump because public octave fields changed from `u8` to `i16` and unsupported chord combinations now return errors. Release validation also found two blockers in the merged MIDI work: playback examples were compiled without their feature, and the exhaustive MIDI test constructed half-diminished and dominant triads even though those qualities require seventh chords.

## Validation

- `cargo test --all-targets`
- `cargo test --all-targets --all-features`
- `cargo test --doc --all-features`
- `wasm-pack test --node`
- `cargo check --example hypnotic_techno --features midi-playback`
- `cargo publish --dry-run --allow-dirty`
- `git diff --check`
