### PR TITLE
Add complete lead-sheet chord symbols

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,29 @@
+## v0.5.0 - 2026-07-12
+
+### Features
+
+- Add complete common jazz/pop lead-sheet chord symbols with aliases, modifiers, slash basses,
+  canonical ASCII formatting, and exact theoretical note spelling
+- Add normalized `ChordSpec`/`ChordFormula` theory types, `Chord::parse`, `FromStr`, `Display`,
+  getters, and `Chord::builder`
+- Add compact chord support and `chord normalize` to the CLI
+- Add `parse_chord_symbol` and normalized chord metadata to WASM
+
+### Fixes
+
+- Preserve power-chord and minor-major quality markers instead of silently reinterpreting invalid
+  combinations
+- Correct scientific octaves and MIDI pitches for theoretical notes such as C-flat and B-sharp
+- Accept Unicode double-flat roots and basses and canonicalize all accidentals to ASCII
+- Report parser error positions against the original input after aliases, Unicode, and whitespace
+  normalization
+- Keep source-position tracking linear for long or adversarial invalid symbols
+
+### Breaking Changes
+
+- Make `Chord` fields private so symbol metadata and playback formulas remain consistent; legacy
+  constructors and quality/number adapters remain available
+
 ## v0.4.0 - 2026-07-12
 
 ### Features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "rust-music-theory"
 description = "A library that procedurally implements music theory notions like Scale, Chord, Interval, Note"
 license = "MIT"
-version = "0.4.0"
+version = "0.5.0"
 readme = "README.md"
 repository = "https://github.com/ozankasikci/rust-music-theory"
 authors = ["Ozan Kaşıkçı <ozan@kasikci.io>"]

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ A library and executable that provides programmatic implementation of the basis 
 
 - [Overview](#overview)
 - [Usage as a Library](#usage-as-a-library)
+- [Lead-Sheet Chord Symbols](#lead-sheet-chord-symbols)
 - [MIDI Support](#midi-support)
 - [Usage as an Executable](#usage-as-an-executable)
 - [Interactive Playground](#interactive-playground)
@@ -25,23 +26,23 @@ Interval and more. The main purpose of this library is to let music theory be us
 Add `rust-music-theory` as a dependency in your Cargo.toml.
 ```toml
 [dependencies]
-rust-music-theory = "0.3"
+rust-music-theory = "0.5"
 ```
 
 After installing the dependencies, you can use the library as follows.
 ```rust
 extern crate rust_music_theory as rustmt;
-use rustmt::note::{Note, Notes, PitchClass};
+use rustmt::note::{Note, Notes, Pitch, PitchSymbol::*};
 use rustmt::scale::{Scale, ScaleType, Mode, Direction};
 use rustmt::chord::{Chord, Number as ChordNumber, Quality as ChordQuality};
 
-// to create a Note, specify a pitch class and an octave;
-let note = Note::new(PitchClass::As, 4);
+// to create a Note, specify a pitch and an octave;
+let note = Note::new(Pitch::from(As), 4);
 
 // Scale Example;
 let scale = Scale::new(
     ScaleType::Diatonic,    // scale type
-    PitchClass::C,          // tonic
+    Pitch::from(C),         // tonic
     4,                      // octave
     Some(Mode::Ionian),     // scale mode
     Direction::Ascending,   // scale direction
@@ -51,7 +52,7 @@ let scale = Scale::new(
 let scale_notes = scale.notes();
 
 // Chord Example;
-let chord = Chord::new(PitchClass::C, ChordQuality::Major, ChordNumber::Triad);
+let chord = Chord::new(Pitch::from(C), ChordQuality::Major, ChordNumber::Triad);
 
 // returns a Vector of the Notes of the chord
 let chord_notes = chord.notes();
@@ -59,6 +60,46 @@ let chord_notes = chord.notes();
 ```
 
 This is the simplest form of the usage. For detailed examples, please see the tests folder.
+
+## Lead-Sheet Chord Symbols
+
+Version 0.5 adds a normalized lead-sheet chord model and a compact parser. Parsing preserves
+generic note spelling, resolves modifiers in musical order, and formats every accepted alias as
+portable ASCII.
+
+```rust
+use rust_music_theory::chord::Chord;
+use rust_music_theory::note::Notes;
+
+let chord = Chord::parse("Cmaj9#11/G")?;
+assert_eq!(chord.canonical_symbol(), "Cmaj9#11/G");
+assert_eq!(
+    chord.notes().iter().map(|note| note.pitch.to_string()).collect::<Vec<_>>(),
+    ["G", "B", "D", "F#", "C", "E"]
+);
+
+// FromStr and Display use the same normalized grammar.
+let half_diminished: Chord = "Cø7".parse()?;
+assert_eq!(half_diminished.to_string(), "Cm7b5");
+# Ok::<(), rust_music_theory::chord::ChordError>(())
+```
+
+Common supported forms include:
+
+- Families: `C`, `Cm`, `Cdim`, `Caug`, `C5`, `C6`, `Cm6`, `C6/9`, `Cm6/9`
+- Sevenths: `C7`, `Cmaj7`, `Cm7`, `CmMaj7`, `Cm7b5`, `Cdim7`, `Caug7`, `CaugMaj7`
+- Extensions: dominant, major, minor, and minor-major `9`, `11`, and `13`
+- Suspensions and additions: `C7sus4`, `Cm7sus4`, `Csus2`, `Cadd2`, `Cadd4`, `Cadd6`, `Cadd9`, `Cadd11`, `Cadd13`
+- Alterations and omissions: `C7b5`, `C7#9`, `Cmaj9#11`, `C7no5`, `C13omit11`
+- Altered and slash chords: `C7alt`, `C/E`, `C/F#`, `C/1`
+- Aliases and groups: `CΔ`, `CΔ9`, `CmΔ`, `C^7`, `CM7`, `Cma7`, `C-7`, `Cmi7`, `Cm/M7`, `C°7`, `Cø7`, `Ch7`, `C+7`, `C69`, `C6add9`, `C7(b9,#11)`
+
+ASCII and Unicode single/double accidentals are accepted on roots and slash basses. Generated note
+octaves follow written scientific pitch, so `Cb4` plays as MIDI 59 and `B#4` as MIDI 72.
+
+`Chord::builder(root)` exposes the same validated model for programmatic construction. See
+[the chord-symbol reference](docs/chord-symbols.md) for grammar, canonicalization, builder usage,
+errors, and the 0.4 to 0.5 migration.
 
 ## MIDI Support
 
@@ -70,7 +111,7 @@ Enable the `midi` feature to export chords and scales to MIDI files:
 
 ```toml
 [dependencies]
-rust-music-theory = { version = "0.4", features = ["midi"] }
+rust-music-theory = { version = "0.5", features = ["midi"] }
 ```
 
 ```rust
@@ -101,7 +142,7 @@ Enable the `midi-playback` feature to play notes on connected MIDI devices (hard
 
 ```toml
 [dependencies]
-rust-music-theory = { version = "0.4", features = ["midi-playback"] }
+rust-music-theory = { version = "0.5", features = ["midi-playback"] }
 ```
 
 ```rust
@@ -168,11 +209,25 @@ Notes:
 ```yaml
 Notes:
   1: C#
-  2: F
+  2: E#
   3: G#
   4: B
   5: D#
-  6: G
+  6: F#
+```
+
+Compact symbols and canonical normalization are also available:
+
+```console
+$ rustmt chord C7sus4
+Notes:
+  1: C
+  2: F
+  3: G
+  4: Bb
+
+$ rustmt chord normalize 'C7(b9,#11)'
+C7b9#11
 ```
 
 `rustmt scale list`
@@ -192,29 +247,12 @@ Available Scales:
 
 `rustmt chord list`
 ```yaml
-Available chords:
- - Major Triad
- - Minor Triad
- - Suspended2 Triad
- - Suspended4 Triad
- - Augmented Triad
- - Diminished Triad
- - Major Seventh
- - Minor Seventh
- - Augmented Seventh
- - Augmented Major Seventh
- - Diminished Seventh
- - Half Diminished Seventh
- - Minor Major Seventh
- - Dominant Seventh
- - Dominant Ninth
- - Major Ninth
- - Dominant Eleventh
- - Major Eleventh
- - Minor Eleventh
- - Dominant Thirteenth
- - Major Thirteenth
- - Minor Thirteenth
+Supported chord syntax:
+ - Major Triad: C
+ - Sevenths: C7, Cmaj7, Cm7, CmMaj7, Cm7b5, Cdim7, Caug7, CaugMaj7
+ - Altered dominant: C7alt
+ - Slash basses and inversions: C/E, C/F#, C/1
+ ...
 ```
 
 ## Interactive Playground
@@ -227,7 +265,9 @@ Try the library in your browser with the interactive WASM playground:
 
 ## Building From Source
 
-The binary is implemented as a regex parser cli that returns the notes of the given scale/chord.
+The binary returns the notes of the requested scale or chord. Chords use the normalized
+Unicode-aware tokenizer; the older regex-named chord entry point is retained only as a deprecated
+compatibility wrapper.
 To quickly build and run the executable locally;
 
 `git clone http://github.com/ozankasikci/rust-music-theory && cd rust-music-theory`

--- a/docs/chord-symbols.md
+++ b/docs/chord-symbols.md
@@ -1,0 +1,149 @@
+# Lead-Sheet Chord Symbols
+
+Rust Music Theory 0.5 represents a chord as a validated `ChordSpec` plus a resolved
+`ChordFormula`. The parser, builder, note generator, CLI, and WASM interface all consume this same
+model, so displayed symbols cannot disagree with playback notes.
+
+## Parsing and canonical formatting
+
+```rust
+use rust_music_theory::chord::Chord;
+
+let chord = Chord::parse("C7(b9,#11)")?;
+assert_eq!(chord.canonical_symbol(), "C7b9#11");
+
+let alias: Chord = "CΔ9".parse()?;
+assert_eq!(alias.to_string(), "Cmaj9");
+# Ok::<(), rust_music_theory::chord::ChordError>(())
+```
+
+Canonical output is ASCII. Input-only aliases include `Δ`, `^`, `M`, `ma`, `-`, `mi`, `min`, `°`,
+`o`, `ø`, `h`, `+`, `69`, `6add9`, minor-major forms such as `m/M7`, English
+quality/extension names, `sus` for `sus4`, parentheses,
+and comma-separated modifiers.
+
+Bare `Δ` means major seventh and `mΔ` means minor-major seventh; numbered forms retain their
+extension (`Δ9`, `Δ13`). Unicode `♭`, `♯`, `𝄫`, and `𝄪` are input aliases and format back to
+portable ASCII accidentals.
+
+The parser resolves a symbol in this order:
+
+1. base triad and extension;
+2. suspension, replacing the third;
+3. alterations, replacing a present degree or adding an absent one;
+4. additions;
+5. omissions.
+
+`sus4add3` explicitly restores the third. Duplicate, contradictory, and redundant modifiers are
+errors. `7alt` is fixed to `1 3 b5 #5 b7 b9 #9` and cannot take additional modifiers.
+Error byte positions always refer to the original UTF-8 input, before alias and whitespace
+normalization.
+
+Modifier formatting is deterministic: suspension, alterations by degree, additions by degree,
+omissions by degree, then slash bass. For example, `C7(no5,add13,#11,b9)` becomes
+`C7b9#11add13no5`.
+
+## Supported families
+
+| Family | Examples |
+| --- | --- |
+| Triads | `C`, `Cm`, `Cdim`, `Caug`, `C5` |
+| Sixths | `C6`, `Cm6`, `C6/9`, `Cm6/9` |
+| Sevenths | `C7`, `Cmaj7`, `Cm7`, `CmMaj7`, `Cm7b5`, `Cdim7`, `Caug7`, `CaugMaj7` |
+| Extensions | dominant, major, minor, and minor-major `9`, `11`, `13` |
+| Suspensions | `Csus2`, `Csus4`, `C7sus4`, `Cm7sus4` |
+| Added tones | `add2`, `add4`, `add6`, `add9`, `add11`, `add13` |
+| Alterations | flat/sharp `5`, `9`, `11`, `13` |
+| Omissions | `no3`, `no5`, `no7`, `no9`, `no11`, `no13`; `omit` is an alias |
+| Altered | `C7alt` |
+| Slash bass | chord-tone inversions and non-chord basses, plus numeric inversions such as `C/1` |
+
+The root and every generated chord tone retain a generic letter. This produces theoretical but
+correct spellings such as `C#maj9#11` = `C# E# G# B# D# F##` and
+`Cb7b9` = `Cb Eb Gb Bbb Dbb`.
+
+Octaves follow the written step, alteration, and octave independently. Consequently `Cb4` has MIDI
+pitch 59 while `B#4` has MIDI pitch 72, and compound additions retain their written octave.
+
+Core formulas follow MusicXML's chord-kind definitions. Extensions are complete structural
+formulas rather than guitar or keyboard voicing suggestions: an eleventh includes its ninth, and
+a thirteenth includes its ninth and eleventh. Simple and compound additions remain distinct in
+the generated octave (`add2` versus `add9`, `add6` versus `add13`). The accepted shorthand aliases
+are informed by Tonal's chord dictionary and ChordPro's built-in extension registry. This crate's
+`7alt` formula is deliberately fixed to `1 3 b5 #5 b7 b9 #9`; it is a documented library contract,
+not an attempt to preserve every external library's different `alt` voicing.
+
+References: [MusicXML chord kinds](https://www.w3.org/2021/06/musicxml40/musicxml-reference/data-types/kind-value/),
+[MusicXML degree operations](https://www.w3.org/2021/06/musicxml40/musicxml-reference/elements/degree/),
+[MusicXML MIDI-compatible pitch](https://www.w3.org/2021/06/musicxml40/tutorial/midi-compatible-part/),
+[Tonal chord dictionary](https://github.com/tonaljs/tonal/blob/main/packages/chord-type/data.ts),
+and [ChordPro chord parsing](https://www.chordpro.org/chordpro/chordpro-chords/).
+
+## Builder and normalized types
+
+```rust
+use rust_music_theory::chord::{Chord, ChordExtension, SeventhQuality};
+use rust_music_theory::note::{NoteLetter, Pitch};
+
+let chord = Chord::builder(Pitch::new(NoteLetter::C, 0))
+    .extension(ChordExtension::Ninth)
+    .seventh_quality(SeventhQuality::Major)
+    .alter(11, 1)?
+    .bass(Pitch::new(NoteLetter::G, 0))
+    .build()?;
+
+assert_eq!(chord.to_string(), "Cmaj9#11/G");
+# Ok::<(), rust_music_theory::chord::ChordError>(())
+```
+
+The public normalized types are `TriadQuality`, `SeventhQuality`, `ChordExtension`, `Suspension`,
+`ChordTone`, `ChordModifier`, `ChordSpec`, and `ChordFormula`. Read them through `Chord::spec()` and
+`Chord::formula()`.
+
+## Slash bass behavior
+
+A chord-member bass becomes an inversion. A non-chord bass is inserted below the chord. Canonical
+formatting always writes the actual note: `C/1` becomes `C/E`.
+
+## Migration from 0.4
+
+The legacy constructors remain available:
+
+```rust
+Chord::new(root, quality, number);
+Chord::try_new(root, quality, number);
+Chord::with_inversion(root, quality, number, inversion);
+```
+
+`Quality` and `Number` now adapt to a validated `ChordSpec`; `Power`, `Fifth`, `Sixth`, and
+`SixNine` cover the added core families. `Chord::from_regex` is deprecated and delegates to
+`Chord::parse`.
+
+Chord fields are private in 0.5. Replace direct access as follows:
+
+| 0.4 | 0.5 |
+| --- | --- |
+| `chord.root` | `chord.root()` |
+| `chord.octave` | `chord.octave()` |
+| `chord.intervals` | `chord.intervals()` |
+| `chord.quality` | `chord.quality()` |
+| `chord.number` | `chord.number()` |
+| `chord.inversion` | `chord.inversion()` |
+| `chord.bass` | `chord.bass()` |
+
+Use `Chord::builder` instead of a struct literal. This prevents interval, symbol, inversion, and
+bass metadata from diverging.
+
+## CLI and WASM
+
+The CLI accepts compact symbols directly and has a normalization command:
+
+```console
+rustmt chord Cmaj9#11/G
+rustmt chord normalize Cø7
+rustmt chord list
+```
+
+WASM callers can use `parse_chord_symbol(symbol)`. It returns a serialized `WasmChord` with
+`canonical_symbol`, `bass`, `modifiers`, `formula`, and notes, or throws the Rust parse error. The
+legacy `generate_chord(root, quality, number)` function remains available.

--- a/src/bin/rustmt.rs
+++ b/src/bin/rustmt.rs
@@ -1,5 +1,5 @@
 use clap::{App, Arg, ArgMatches};
-use rust_music_theory::chord::Chord;
+use rust_music_theory::chord::{Chord, SUPPORTED_CHORD_SYNTAX};
 use rust_music_theory::note::Notes;
 use rust_music_theory::scale::{Direction, Scale};
 
@@ -18,32 +18,6 @@ const AVAILABLE_SCALES: [&str; 14] = [
     "Blues",
     "Chromatic",
     "Whole Tone",
-];
-
-const AVAILABLE_CHORDS: [&str; 23] = [
-    "Major Triad",
-    "Minor Triad",
-    "Suspended2 Triad",
-    "Suspended4 Triad",
-    "Augmented Triad",
-    "Diminished Triad",
-    "Major Seventh",
-    "Minor Seventh",
-    "Augmented Seventh",
-    "Augmented Major Seventh",
-    "Diminished Seventh",
-    "Half Diminished Seventh",
-    "Minor Major Seventh",
-    "Dominant Seventh",
-    "Dominant Ninth",
-    "Major Ninth",
-    "Minor Ninth",
-    "Dominant Eleventh",
-    "Major Eleventh",
-    "Minor Eleventh",
-    "Dominant Thirteenth",
-    "Major Thirteenth",
-    "Minor Thirteenth",
 ];
 
 fn scale_command(scale_matches: &ArgMatches) {
@@ -71,30 +45,41 @@ fn scale_command(scale_matches: &ArgMatches) {
     }
 }
 
-fn chord_command(chord_matches: &ArgMatches) {
+fn joined_args(matches: &ArgMatches) -> Result<String, String> {
+    matches
+        .values_of("args")
+        .map(|values| values.collect::<Vec<_>>().join(" "))
+        .filter(|value| !value.trim().is_empty())
+        .ok_or_else(|| "missing chord symbol".to_string())
+}
+
+fn chord_command(chord_matches: &ArgMatches) -> Result<(), String> {
     match chord_matches.subcommand() {
         ("list", _) => {
-            println!("Available chords:");
-            for chord in &AVAILABLE_CHORDS {
-                println!(" - {}", chord);
+            println!("Supported chord syntax:");
+            for syntax in SUPPORTED_CHORD_SYNTAX {
+                println!(" - {}", syntax);
             }
+            Ok(())
+        }
+        ("normalize", Some(normalize_matches)) => {
+            let symbol = joined_args(normalize_matches)?;
+            let chord = Chord::parse(&symbol).map_err(|error| error.to_string())?;
+            println!("{}", chord.canonical_symbol());
+            Ok(())
         }
         _ => {
-            let chord_args = chord_matches
-                .values_of("args")
-                .unwrap()
-                .collect::<Vec<_>>()
-                .join(" ");
-
-            let chord = Chord::from_regex(&chord_args).unwrap();
+            let chord_args = joined_args(chord_matches)?;
+            let chord = Chord::parse(&chord_args).map_err(|error| error.to_string())?;
             chord.print_notes();
+            Ok(())
         }
     }
 }
 
 fn main() {
     let matches = App::new("RustMusicTheory")
-        .version("0.1")
+        .version(env!("CARGO_PKG_VERSION"))
         .author("Ozan Kaşıkçı")
         .about("A music theory guide")
         .subcommand(
@@ -117,6 +102,16 @@ fn main() {
             App::new("chord")
                 .about("Provides information for the specified chord")
                 .subcommand(App::new("list").about("Prints out the available chords"))
+                .subcommand(
+                    App::new("normalize")
+                        .about("Prints the canonical ASCII form of a chord symbol")
+                        .arg(
+                            Arg::with_name("args")
+                                .help("chord symbol, for example C7(b9,#11)")
+                                .required(true)
+                                .multiple(true),
+                        ),
+                )
                 .arg(
                     Arg::with_name("args")
                         .help("chord args, examples:\nC minor\nAb augmented major seventh\nF# dominant seventh / C#\nC/1")
@@ -125,15 +120,22 @@ fn main() {
         )
         .get_matches();
 
-    match matches.subcommand() {
+    let result = match matches.subcommand() {
         ("scale", Some(scale_matches)) => {
             scale_command(scale_matches);
+            Ok(())
         }
 
-        ("chord", Some(chord_matches)) => {
-            chord_command(chord_matches);
-        }
+        ("chord", Some(chord_matches)) => chord_command(chord_matches),
 
-        _ => println!("Please use the help command to see the available commands"),
+        _ => {
+            println!("Please use the help command to see the available commands");
+            Ok(())
+        }
+    };
+
+    if let Err(message) = result {
+        eprintln!("error: {}", message);
+        std::process::exit(2);
     }
 }

--- a/src/chord.rs
+++ b/src/chord.rs
@@ -3,9 +3,37 @@
 mod chord;
 mod errors;
 mod number;
+mod parser;
 mod quality;
+mod spec;
 
-pub use chord::Chord;
+pub use chord::{Chord, ChordBuilder};
 pub use errors::ChordError;
 pub use number::Number;
 pub use quality::Quality;
+pub use spec::{
+    ChordExtension, ChordFormula, ChordModifier, ChordSpec, ChordTone, SeventhQuality, Suspension,
+    TriadQuality,
+};
+
+/// Human-readable syntax registry used by documentation and command-line discovery.
+pub const SUPPORTED_CHORD_SYNTAX: &[&str] = &[
+    "Major Triad: C",
+    "Minor Triad: Cm",
+    "Diminished Triad: Cdim",
+    "Augmented Triad: Caug",
+    "Power Chord: C5",
+    "Sixths: C6, Cm6, C6/9, Cm6/9",
+    "Sevenths: C7, Cmaj7, Cm7, CmMaj7, Cm7b5, Cdim7, Caug7, CaugMaj7",
+    "Ninths: C9, Cmaj9, Cm9, CmMaj9",
+    "Elevenths: C11, Cmaj11, Cm11, CmMaj11",
+    "Thirteenths: C13, Cmaj13, Cm13, CmMaj13",
+    "Suspensions: Csus2, Csus4, C7sus4, Cm7sus4",
+    "Added tones: Cadd2, Cadd4, Cadd6, Cadd9, Cadd11, Cadd13",
+    "Alterations: C7b5, C7#5, C7b9, C7#9, Cmaj9#11, C13b13",
+    "Omissions: Cno3, C7no5, C13omit11",
+    "Altered dominant: C7alt",
+    "Slash basses and inversions: C/E, C/F#, C/1",
+    "Aliases: CΔ, CΔ9, CmΔ, C^7, CM7, Cma7, C-7, Cmi7, Cm/M7, C°7, Cø7, Ch7, C+7, C69, C6add9",
+    "Grouped modifiers: C7(b9,#11)",
+];

--- a/src/chord/chord.rs
+++ b/src/chord/chord.rs
@@ -1,67 +1,164 @@
 use crate::chord::errors::ChordError;
-use crate::chord::number::Number::Triad;
-use crate::chord::{Number, Quality};
+use crate::chord::parser::{parse_chord, ParsedSlash};
+use crate::chord::spec::format_modifier;
+use crate::chord::{
+    ChordExtension, ChordFormula, ChordModifier, ChordSpec, ChordTone, Number, Quality,
+    SeventhQuality, Suspension, TriadQuality,
+};
 use crate::interval::Interval;
 use crate::note::{Note, NoteLetter, Notes, Pitch};
+use std::fmt;
+use std::str::FromStr;
 
-/// A chord.
-#[derive(Debug, Clone)]
+/// A validated lead-sheet chord, including its voicing and optional slash bass.
+#[derive(Debug, Clone, PartialEq)]
 pub struct Chord {
-    /// The root note of the chord.
-    pub root: Pitch,
-    /// The octave of the root note of the chord.
-    pub octave: i16,
-    /// The intervals within the chord.
-    pub intervals: Vec<Interval>,
-    /// The quality of the chord: major, minor, diminished, etc.
-    pub quality: Quality,
-    /// The superscript number of the chord: 3, 7, maj7, etc.
-    pub number: Number,
-    /// The inversion of the chord: 0=root position, 1=first inversion, etc.
-    pub inversion: u8,
-    /// A non-chord bass note supplied by a slash chord such as C/F#.
-    pub bass: Option<Pitch>,
+    root: Pitch,
+    octave: i16,
+    spec: ChordSpec,
+    formula: ChordFormula,
+    intervals: Vec<Interval>,
+    inversion: u8,
+    slash_bass: Option<Pitch>,
+    legacy_quality: Quality,
+    legacy_number: Number,
 }
 
 impl Chord {
-    /// Create a new chord.
+    /// Create a chord through the legacy quality/number API.
     pub fn new(root: Pitch, quality: Quality, number: Number) -> Self {
         Self::try_new(root, quality, number).expect("unsupported chord quality/number combination")
     }
 
-    /// Try to create a new chord, returning an error for unsupported quality/number combinations.
+    /// Try to create a chord through the legacy quality/number API.
     pub fn try_new(root: Pitch, quality: Quality, number: Number) -> Result<Self, ChordError> {
         Self::try_with_inversion(root, quality, number, 0)
     }
 
-    /// Create a new chord with a given inversion.
+    /// Create a chord through the legacy API with a numeric inversion.
     pub fn with_inversion(root: Pitch, quality: Quality, number: Number, inversion: u8) -> Self {
         Self::try_with_inversion(root, quality, number, inversion)
             .expect("unsupported chord or invalid inversion")
     }
 
-    /// Try to create a chord in a specific inversion.
+    /// Try to create a chord through the legacy API with a numeric inversion.
     pub fn try_with_inversion(
         root: Pitch,
         quality: Quality,
         number: Number,
         inversion: u8,
     ) -> Result<Self, ChordError> {
-        let intervals = Self::try_chord_intervals(quality, number)?;
-        if inversion as usize > intervals.len() {
-            return Err(ChordError::InvalidInversion(inversion));
-        }
-        Ok(Chord {
+        let spec = legacy_spec(quality, number)?;
+        let mut chord = Self::from_spec(root, spec)?;
+        chord.legacy_quality = quality;
+        chord.legacy_number = number;
+        chord.set_inversion(inversion)?;
+        Ok(chord)
+    }
+
+    /// Create a chord from a normalized specification.
+    pub fn from_spec(root: Pitch, spec: ChordSpec) -> Result<Self, ChordError> {
+        let formula = spec.formula()?;
+        let intervals = formula_intervals(&formula)?;
+        let legacy_quality = legacy_quality(&spec);
+        let legacy_number = legacy_number(&spec);
+        Ok(Self {
             root,
             octave: 4,
+            spec,
+            formula,
             intervals,
-            quality,
-            number,
-            inversion,
-            bass: None,
+            inversion: 0,
+            slash_bass: None,
+            legacy_quality,
+            legacy_number,
         })
     }
 
+    /// Parse a compact or long-form lead-sheet chord symbol.
+    pub fn parse(symbol: &str) -> Result<Self, ChordError> {
+        let parsed = parse_chord(symbol)?;
+        let mut chord = Self::from_spec(parsed.root, parsed.spec)?;
+        match parsed.slash {
+            Some(ParsedSlash::Inversion { value, position }) => chord
+                .set_inversion(value)
+                .map_err(|_| ChordError::InvalidSlashBass { position })?,
+            Some(ParsedSlash::Bass(bass)) => chord.set_bass(bass)?,
+            None => {}
+        }
+        Ok(chord)
+    }
+
+    /// Start a programmatic chord specification.
+    pub fn builder(root: Pitch) -> ChordBuilder {
+        ChordBuilder::new(root)
+    }
+
+    /// The written chord root.
+    pub fn root(&self) -> Pitch {
+        self.root
+    }
+
+    /// The octave used for the first voiced note.
+    pub fn octave(&self) -> i16 {
+        self.octave
+    }
+
+    /// The normalized theory specification.
+    pub fn spec(&self) -> &ChordSpec {
+        &self.spec
+    }
+
+    /// The fully resolved and sorted chord tones.
+    pub fn formula(&self) -> &ChordFormula {
+        &self.formula
+    }
+
+    /// Adjacent semitone intervals retained for legacy consumers.
+    pub fn intervals(&self) -> &[Interval] {
+        &self.intervals
+    }
+
+    /// Numeric inversion, where zero is root position.
+    pub fn inversion(&self) -> u8 {
+        self.inversion
+    }
+
+    /// The actual slash bass, whether supplied as a note or numeric inversion.
+    pub fn bass(&self) -> Option<Pitch> {
+        if let Some(bass) = self.slash_bass {
+            Some(bass)
+        } else if self.inversion > 0 {
+            self.root_position_notes()
+                .get(self.inversion as usize)
+                .map(|note| note.pitch)
+        } else {
+            None
+        }
+    }
+
+    /// Legacy quality adapter for this chord's normalized specification.
+    pub fn quality(&self) -> Quality {
+        self.legacy_quality
+    }
+
+    /// Legacy number adapter for this chord's normalized specification.
+    pub fn number(&self) -> Number {
+        self.legacy_number
+    }
+
+    /// Return the canonical, portable ASCII chord symbol.
+    pub fn canonical_symbol(&self) -> String {
+        self.to_string()
+    }
+
+    /// Return a copy voiced in a different octave.
+    pub fn with_octave(mut self, octave: i16) -> Self {
+        self.octave = octave;
+        self
+    }
+
+    /// Parse a whitespace-separated set of chord notes and recognize a legacy formula.
     pub fn from_string(string: &str) -> Result<Self, ChordError> {
         let normalized = string.replace(',', "");
         let notes: Vec<Pitch> = normalized
@@ -86,19 +183,25 @@ impl Chord {
             })
             .collect();
 
-        Chord::from_interval(notes[0], &intervals)
+        Self::from_interval(notes[0], &intervals)
     }
 
+    /// Recognize an adjacent-semitone legacy formula.
     pub fn from_interval(root: Pitch, interval: &[u8]) -> Result<Self, ChordError> {
         use Number::*;
         use Quality::*;
         let (quality, number) = match *interval {
+            [7] => (Power, Fifth),
             [4, 3] => (Major, Triad),
             [3, 4] => (Minor, Triad),
             [2, 5] => (Suspended2, Triad),
             [5, 2] => (Suspended4, Triad),
             [4, 4] => (Augmented, Triad),
             [3, 3] => (Diminished, Triad),
+            [4, 3, 2] => (Major, Sixth),
+            [3, 4, 2] => (Minor, Sixth),
+            [4, 3, 2, 5] => (Major, SixNine),
+            [3, 4, 2, 5] => (Minor, SixNine),
             [4, 3, 4] => (Major, Seventh),
             [3, 4, 3] => (Minor, Seventh),
             [4, 4, 2] => (Augmented, Seventh),
@@ -126,200 +229,502 @@ impl Chord {
             .expect("unsupported chord quality/number combination")
     }
 
-    /// Return the adjacent intervals for a supported chord.
+    /// Return adjacent intervals for a chord accepted by the legacy adapters.
     pub fn try_chord_intervals(
         quality: Quality,
         number: Number,
     ) -> Result<Vec<Interval>, ChordError> {
-        use Number::*;
-        use Quality::*;
-        let semitones: &[u8] = match (&quality, &number) {
-            (Major, Triad) => &[4, 3],
-            (Minor, Triad) => &[3, 4],
-            (Suspended2, Triad) => &[2, 5],
-            (Suspended4, Triad) => &[5, 2],
-            (Augmented, Triad) => &[4, 4],
-            (Diminished, Triad) => &[3, 3],
-            (Major, Seventh | MajorSeventh) => &[4, 3, 4],
-            (Minor, Seventh) => &[3, 4, 3],
-            (Augmented, Seventh) => &[4, 4, 2],
-            (Augmented, MajorSeventh) => &[4, 4, 3],
-            (Diminished, Seventh) => &[3, 3, 3],
-            (HalfDiminished, Seventh) => &[3, 3, 4],
-            (Minor, MajorSeventh) => &[3, 4, 4],
-            (Dominant, Seventh) => &[4, 3, 3],
-            (Dominant, Ninth) => &[4, 3, 3, 4],
-            (Major, Ninth) => &[4, 3, 4, 3],
-            (Minor, Ninth) => &[3, 4, 3, 4],
-            (Dominant, Eleventh) => &[4, 3, 3, 4, 3],
-            (Major, Eleventh) => &[4, 3, 4, 3, 3],
-            (Minor, Eleventh) => &[3, 4, 3, 4, 3],
-            (Dominant, Thirteenth) => &[4, 3, 3, 4, 3, 4],
-            (Major, Thirteenth) => &[4, 3, 4, 3, 3, 4],
-            (Minor, Thirteenth) => &[3, 4, 3, 4, 3, 4],
-            _ => {
-                return Err(ChordError::UnsupportedChord(format!(
-                    "{} {}",
-                    quality, number
-                )))
-            }
-        };
-        Ok(Interval::from_semitones(semitones).unwrap())
+        let spec = legacy_spec(quality, number)?;
+        formula_intervals(&spec.formula()?)
     }
 
-    /// Parse a chord using a regex.
+    /// Deprecated compatibility name for [`Chord::parse`].
+    #[deprecated(since = "0.5.0", note = "use Chord::parse or str::parse")]
     pub fn from_regex(string: &str) -> Result<Self, ChordError> {
-        let string = string.trim();
-        let (pitch, pitch_match) = Pitch::from_regex(string)?;
-        let remainder = &string[pitch_match.end()..];
-        let (descriptor, slash) = if let Some((descriptor, slash)) = remainder.split_once('/') {
-            if slash.contains('/') || slash.trim().is_empty() {
-                return Err(ChordError::InvalidRegex);
-            }
-            (descriptor.trim(), Some(slash.trim()))
-        } else {
-            (remainder.trim(), None)
-        };
+        Self::parse(string)
+    }
 
-        let (quality, number) = if descriptor.is_empty() {
-            (Quality::Major, Triad)
-        } else if let Ok((number, number_match)) = Number::from_regex(descriptor) {
-            let number_match = number_match.ok_or(ChordError::InvalidRegex)?;
-            if number_match.start() != 0 || number_match.end() != descriptor.len() {
-                return Err(ChordError::InvalidRegex);
-            }
-            let quality = match number {
-                Number::MajorSeventh => Quality::Major,
-                Number::Seventh | Number::Ninth | Number::Eleventh | Number::Thirteenth => {
-                    Quality::Dominant
-                }
-                Number::Triad => Quality::Major,
-            };
-            (quality, number)
-        } else if let Some((quality, number_string)) = descriptor
-            .strip_prefix('m')
-            .map(|rest| (Quality::Minor, rest))
-            .or_else(|| descriptor.strip_prefix('M').map(|rest| (Quality::Major, rest)))
-            .filter(|(_, rest)| !rest.is_empty() && Number::from_regex(rest).is_ok())
-        {
-            let (number, number_match) = Number::from_regex(number_string)?;
-            let number_match = number_match.ok_or(ChordError::InvalidRegex)?;
-            if number_match.start() != 0 || number_match.end() != number_string.len() {
-                return Err(ChordError::InvalidRegex);
-            }
-            (quality, number)
-        } else {
-            let (quality, quality_match) = Quality::from_regex(descriptor)?;
-            let quality_match = quality_match.ok_or(ChordError::InvalidRegex)?;
-            if quality_match.start() != 0 {
-                return Err(ChordError::InvalidRegex);
-            }
-            let number_string = descriptor[quality_match.end()..].trim();
-            let number = if number_string.is_empty() {
-                Triad
-            } else {
-                let (number, number_match) = Number::from_regex(number_string)?;
-                let number_match = number_match.ok_or(ChordError::InvalidRegex)?;
-                if number_match.start() != 0 || number_match.end() != number_string.len() {
-                    return Err(ChordError::InvalidRegex);
-                }
-                number
-            };
-            (quality, number)
-        };
-
-        let mut chord = Chord::try_new(pitch, quality, number)?;
-        if let Some(slash) = slash {
-            if let Ok(inversion) = slash.parse::<u8>() {
-                return Chord::try_with_inversion(pitch, quality, number, inversion);
-            }
-            let (bass_note, bass_match) = Pitch::from_regex(slash)?;
-            if bass_match.end() != slash.len() {
-                return Err(ChordError::InvalidRegex);
-            }
-            let inversion = chord
-                .notes()
-                .iter()
-                .position(|note| note.pitch == bass_note)
-                .map(|position| position as u8);
-            if let Some(inversion) = inversion {
-                chord = Chord::try_with_inversion(pitch, quality, number, inversion)?;
-            } else {
-                chord.bass = Some(bass_note);
-            }
+    fn set_inversion(&mut self, inversion: u8) -> Result<(), ChordError> {
+        if inversion as usize >= self.formula.tones().len() {
+            return Err(ChordError::InvalidInversion(inversion));
         }
+        self.inversion = inversion;
+        self.slash_bass = None;
+        Ok(())
+    }
 
-        Ok(chord)
+    fn set_bass(&mut self, bass: Pitch) -> Result<(), ChordError> {
+        if let Some(index) = self
+            .root_position_notes()
+            .iter()
+            .position(|note| note.pitch.into_u8() == bass.into_u8())
+        {
+            self.set_inversion(index as u8)?;
+        } else {
+            self.inversion = 0;
+            self.slash_bass = Some(bass);
+        }
+        Ok(())
+    }
+
+    fn root_position_notes(&self) -> Vec<Note> {
+        let root_pitch = self.root.into_u8() as i16;
+        self.formula
+            .tones()
+            .iter()
+            .map(|tone| {
+                let absolute = root_pitch + tone.semitones();
+                let letter_steps = tone.degree() as i16 - 1;
+                let letter = self.root.letter.offset(letter_steps);
+                let pitch = Pitch::from_u8_with_letter(absolute.rem_euclid(12) as u8, letter);
+                let octave_delta = (self.root.letter.index() + letter_steps).div_euclid(7);
+                Note::new(pitch, self.octave.saturating_add(octave_delta))
+            })
+            .collect()
+    }
+}
+
+impl FromStr for Chord {
+    type Err = ChordError;
+
+    fn from_str(symbol: &str) -> Result<Self, Self::Err> {
+        Self::parse(symbol)
+    }
+}
+
+impl fmt::Display for Chord {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}{}", self.root, canonical_descriptor(&self.spec))?;
+        if let Some(bass) = self.bass() {
+            write!(f, "/{}", bass)?;
+        }
+        Ok(())
     }
 }
 
 impl Notes for Chord {
     fn notes(&self) -> Vec<Note> {
-        let root_note = Note {
-            pitch: self.root,
-            octave: self.octave,
-        };
-        let mut notes = Interval::to_notes(root_note, self.intervals.clone());
-
-        // Chord members are spelled by their generic interval above the root,
-        // rather than by a global sharp/flat preference.
-        let letter_offsets: &[i16] = match (self.quality, self.number) {
-            (Quality::Suspended2, Number::Triad) => &[0, 1, 4],
-            (Quality::Suspended4, Number::Triad) => &[0, 3, 4],
-            (_, Number::Triad) => &[0, 2, 4],
-            (_, Number::Seventh | Number::MajorSeventh) => &[0, 2, 4, 6],
-            (_, Number::Ninth) => &[0, 2, 4, 6, 8],
-            (_, Number::Eleventh) => &[0, 2, 4, 6, 8, 10],
-            (_, Number::Thirteenth) => &[0, 2, 4, 6, 8, 10, 12],
-        };
-        for (note, letter_offset) in notes.iter_mut().zip(letter_offsets) {
-            let letter = self.root.letter.offset(*letter_offset);
-            note.pitch = Pitch::from_u8_with_letter(note.pitch.into_u8(), letter);
+        let mut notes = self.root_position_notes();
+        if self.inversion == 0 && self.slash_bass.is_none() {
+            return notes;
         }
-
         notes.rotate_left(self.inversion as usize);
 
-        // Normalize to the correct octave
-        if notes[0].octave > self.octave {
-            let diff = notes[0].octave - self.octave;
-            notes.iter_mut().for_each(|note| note.octave -= diff);
-        }
-
-        // Ensure that octave increments at the right notes
-        for i in 1..notes.len() {
-            if notes[i].pitch.into_u8() <= notes[i - 1].pitch.into_u8() {
-                notes[i].octave = notes[i - 1].octave + 1;
-            } else if notes[i].octave < notes[i - 1].octave {
-                notes[i].octave = notes[i - 1].octave;
+        if self.inversion > 0 {
+            notes[0].octave = self.octave;
+            let mut previous_absolute = note_absolute(&notes[0]);
+            for note in notes.iter_mut().skip(1) {
+                note.octave = self.octave;
+                while note_absolute(note) <= previous_absolute && note.octave < i16::MAX {
+                    note.octave += 1;
+                }
+                previous_absolute = note_absolute(note);
             }
         }
 
-        if let Some(bass) = self.bass {
+        if let Some(bass) = self.slash_bass {
             let first = &notes[0];
-            let bass_octave = if bass.into_u8() < first.pitch.into_u8() {
-                first.octave
-            } else {
-                first.octave - 1
-            };
-            notes.insert(0, Note::new(bass, bass_octave));
+            let first_absolute = note_absolute(first);
+            let mut bass_note = Note::new(bass, first.octave);
+            while note_absolute(&bass_note) >= first_absolute && bass_note.octave > i16::MIN {
+                bass_note.octave -= 1;
+            }
+            notes.insert(0, bass_note);
         }
         notes
     }
 }
 
+fn note_absolute(note: &Note) -> i32 {
+    let natural = match note.pitch.letter {
+        NoteLetter::C => 0,
+        NoteLetter::D => 2,
+        NoteLetter::E => 4,
+        NoteLetter::F => 5,
+        NoteLetter::G => 7,
+        NoteLetter::A => 9,
+        NoteLetter::B => 11,
+    };
+    note.octave as i32 * 12 + natural + note.pitch.accidental as i32
+}
+
 impl Default for Chord {
     fn default() -> Self {
-        Chord {
-            root: Pitch {
-                letter: NoteLetter::C,
-                accidental: 0,
-            },
+        Self::new(Pitch::new(NoteLetter::C, 0), Quality::Major, Number::Triad)
+    }
+}
+
+/// Builder for normalized chord specifications, modifiers and slash basses.
+#[derive(Debug, Clone)]
+pub struct ChordBuilder {
+    root: Pitch,
+    octave: i16,
+    triad_quality: TriadQuality,
+    seventh_quality: Option<SeventhQuality>,
+    extension: ChordExtension,
+    suspension: Option<Suspension>,
+    modifiers: Vec<ChordModifier>,
+    inversion: u8,
+    bass: Option<Pitch>,
+}
+
+impl ChordBuilder {
+    fn new(root: Pitch) -> Self {
+        Self {
+            root,
             octave: 4,
-            intervals: vec![],
-            quality: Quality::Major,
-            number: Number::Triad,
+            triad_quality: TriadQuality::Major,
+            seventh_quality: None,
+            extension: ChordExtension::Triad,
+            suspension: None,
+            modifiers: Vec::new(),
             inversion: 0,
             bass: None,
         }
     }
+
+    pub fn octave(mut self, octave: i16) -> Self {
+        self.octave = octave;
+        self
+    }
+
+    pub fn triad_quality(mut self, quality: TriadQuality) -> Self {
+        self.triad_quality = quality;
+        self
+    }
+
+    pub fn seventh_quality(mut self, quality: SeventhQuality) -> Self {
+        self.seventh_quality = Some(quality);
+        self
+    }
+
+    pub fn extension(mut self, extension: ChordExtension) -> Self {
+        self.extension = extension;
+        self
+    }
+
+    pub fn suspension(mut self, suspension: Suspension) -> Self {
+        self.suspension = Some(suspension);
+        self
+    }
+
+    pub fn add(mut self, degree: u8, alteration: i8) -> Result<Self, ChordError> {
+        self.modifiers
+            .push(ChordModifier::Add(ChordTone::new(degree, alteration)?));
+        Ok(self)
+    }
+
+    pub fn alter(mut self, degree: u8, alteration: i8) -> Result<Self, ChordError> {
+        self.modifiers
+            .push(ChordModifier::Alter(ChordTone::new(degree, alteration)?));
+        Ok(self)
+    }
+
+    pub fn omit(mut self, degree: u8) -> Self {
+        self.modifiers.push(ChordModifier::Omit(degree));
+        self
+    }
+
+    pub fn altered(mut self) -> Self {
+        self.modifiers.push(ChordModifier::Altered);
+        self
+    }
+
+    pub fn inversion(mut self, inversion: u8) -> Self {
+        self.inversion = inversion;
+        self.bass = None;
+        self
+    }
+
+    pub fn bass(mut self, bass: Pitch) -> Self {
+        self.bass = Some(bass);
+        self
+    }
+
+    pub fn build(self) -> Result<Chord, ChordError> {
+        let spec = ChordSpec::from_parts(
+            self.triad_quality,
+            self.seventh_quality,
+            self.extension,
+            self.suspension,
+            self.modifiers,
+        )?;
+        let mut chord = Chord::from_spec(self.root, spec)?.with_octave(self.octave);
+        if let Some(bass) = self.bass {
+            chord.set_bass(bass)?;
+        } else {
+            chord.set_inversion(self.inversion)?;
+        }
+        Ok(chord)
+    }
+}
+
+fn formula_intervals(formula: &ChordFormula) -> Result<Vec<Interval>, ChordError> {
+    let semitones: Vec<u8> = formula
+        .tones()
+        .windows(2)
+        .map(|window| {
+            let difference = window[1].semitones() - window[0].semitones();
+            let simple = difference.rem_euclid(12);
+            if simple == 0 {
+                12
+            } else {
+                simple as u8
+            }
+        })
+        .collect();
+    Interval::from_semitones(&semitones).map_err(|_| {
+        ChordError::InvalidSpecification("formula cannot be represented as intervals".to_string())
+    })
+}
+
+fn legacy_spec(quality: Quality, number: Number) -> Result<ChordSpec, ChordError> {
+    use Number::*;
+    use Quality::*;
+
+    if quality == Power {
+        if matches!(number, Triad | Fifth) {
+            return ChordSpec::new(TriadQuality::Power, None, ChordExtension::Triad);
+        }
+        return unsupported(quality, number);
+    }
+    if number == Fifth {
+        return unsupported(quality, number);
+    }
+    if quality == HalfDiminished && number != Seventh {
+        return unsupported(quality, number);
+    }
+
+    let supported = match quality {
+        Major | Minor => matches!(
+            number,
+            Triad | Sixth | SixNine | Seventh | MajorSeventh | Ninth | Eleventh | Thirteenth
+        ),
+        Dominant => matches!(number, Seventh | Ninth | Eleventh | Thirteenth),
+        Diminished => matches!(number, Triad | Seventh),
+        HalfDiminished => number == Seventh,
+        Augmented => matches!(number, Triad | Seventh | MajorSeventh),
+        Suspended2 | Suspended4 => number == Triad,
+        Power => unreachable!(),
+    };
+    if !supported {
+        return unsupported(quality, number);
+    }
+
+    let extension = match number {
+        Triad => ChordExtension::Triad,
+        Sixth => ChordExtension::Sixth,
+        SixNine => ChordExtension::SixNine,
+        Seventh | MajorSeventh => ChordExtension::Seventh,
+        Ninth => ChordExtension::Ninth,
+        Eleventh => ChordExtension::Eleventh,
+        Thirteenth => ChordExtension::Thirteenth,
+        Fifth => unreachable!(),
+    };
+
+    let (triad, suspension) = match quality {
+        Major | Dominant => (TriadQuality::Major, None),
+        Minor => (TriadQuality::Minor, None),
+        Diminished | HalfDiminished => (TriadQuality::Diminished, None),
+        Augmented => (TriadQuality::Augmented, None),
+        Suspended2 => (TriadQuality::Major, Some(Suspension::Second)),
+        Suspended4 => (TriadQuality::Major, Some(Suspension::Fourth)),
+        Power => unreachable!(),
+    };
+
+    if matches!(triad, TriadQuality::Diminished | TriadQuality::Augmented)
+        && !matches!(extension, ChordExtension::Triad | ChordExtension::Seventh)
+    {
+        return unsupported(quality, number);
+    }
+    if matches!(extension, ChordExtension::Sixth | ChordExtension::SixNine)
+        && !matches!(triad, TriadQuality::Major | TriadQuality::Minor)
+    {
+        return unsupported(quality, number);
+    }
+
+    let seventh = if matches!(
+        extension,
+        ChordExtension::Seventh
+            | ChordExtension::Ninth
+            | ChordExtension::Eleventh
+            | ChordExtension::Thirteenth
+    ) {
+        Some(if number == MajorSeventh {
+            SeventhQuality::Major
+        } else {
+            match quality {
+                Major => SeventhQuality::Major,
+                Diminished => SeventhQuality::Diminished,
+                HalfDiminished | Dominant | Minor | Suspended2 | Suspended4 | Augmented => {
+                    SeventhQuality::Minor
+                }
+                Power => unreachable!(),
+            }
+        })
+    } else {
+        None
+    };
+
+    ChordSpec::from_parts(triad, seventh, extension, suspension, Vec::new())
+}
+
+fn unsupported<T>(quality: Quality, number: Number) -> Result<T, ChordError> {
+    Err(ChordError::UnsupportedChord(format!(
+        "{} {}",
+        quality, number
+    )))
+}
+
+fn legacy_quality(spec: &ChordSpec) -> Quality {
+    if let Some(suspension) = spec.suspension() {
+        return match suspension {
+            Suspension::Second => Quality::Suspended2,
+            Suspension::Fourth => Quality::Suspended4,
+        };
+    }
+    match spec.triad_quality() {
+        TriadQuality::Power => Quality::Power,
+        TriadQuality::Minor => Quality::Minor,
+        TriadQuality::Diminished => {
+            if spec.seventh_quality() == Some(SeventhQuality::Minor) {
+                Quality::HalfDiminished
+            } else {
+                Quality::Diminished
+            }
+        }
+        TriadQuality::Augmented => Quality::Augmented,
+        TriadQuality::Major => {
+            if spec.seventh_quality() == Some(SeventhQuality::Minor) {
+                Quality::Dominant
+            } else {
+                Quality::Major
+            }
+        }
+    }
+}
+
+fn legacy_number(spec: &ChordSpec) -> Number {
+    match spec.extension() {
+        ChordExtension::Triad => {
+            if spec.triad_quality() == TriadQuality::Power {
+                Number::Fifth
+            } else {
+                Number::Triad
+            }
+        }
+        ChordExtension::Sixth => Number::Sixth,
+        ChordExtension::SixNine => Number::SixNine,
+        ChordExtension::Seventh => {
+            if spec.seventh_quality() == Some(SeventhQuality::Major) {
+                Number::MajorSeventh
+            } else {
+                Number::Seventh
+            }
+        }
+        ChordExtension::Ninth => Number::Ninth,
+        ChordExtension::Eleventh => Number::Eleventh,
+        ChordExtension::Thirteenth => Number::Thirteenth,
+    }
+}
+
+fn canonical_descriptor(spec: &ChordSpec) -> String {
+    if spec.modifiers() == [ChordModifier::Altered] {
+        return "7alt".to_string();
+    }
+
+    let extension = spec.extension();
+    let seventh = spec.seventh_quality();
+    let mut descriptor = match (spec.triad_quality(), extension, seventh) {
+        (TriadQuality::Power, ChordExtension::Triad, _) => "5".to_string(),
+        (TriadQuality::Major, ChordExtension::Triad, _) => String::new(),
+        (TriadQuality::Major, ChordExtension::Sixth, _) => "6".to_string(),
+        (TriadQuality::Major, ChordExtension::SixNine, _) => "6/9".to_string(),
+        (TriadQuality::Major, ChordExtension::Seventh, Some(SeventhQuality::Minor)) => {
+            "7".to_string()
+        }
+        (TriadQuality::Major, ChordExtension::Seventh, Some(SeventhQuality::Major)) => {
+            "maj7".to_string()
+        }
+        (TriadQuality::Major, ChordExtension::Ninth, Some(SeventhQuality::Minor)) => {
+            "9".to_string()
+        }
+        (TriadQuality::Major, ChordExtension::Ninth, Some(SeventhQuality::Major)) => {
+            "maj9".to_string()
+        }
+        (TriadQuality::Major, ChordExtension::Eleventh, Some(SeventhQuality::Minor)) => {
+            "11".to_string()
+        }
+        (TriadQuality::Major, ChordExtension::Eleventh, Some(SeventhQuality::Major)) => {
+            "maj11".to_string()
+        }
+        (TriadQuality::Major, ChordExtension::Thirteenth, Some(SeventhQuality::Minor)) => {
+            "13".to_string()
+        }
+        (TriadQuality::Major, ChordExtension::Thirteenth, Some(SeventhQuality::Major)) => {
+            "maj13".to_string()
+        }
+        (TriadQuality::Minor, ChordExtension::Triad, _) => "m".to_string(),
+        (TriadQuality::Minor, ChordExtension::Sixth, _) => "m6".to_string(),
+        (TriadQuality::Minor, ChordExtension::SixNine, _) => "m6/9".to_string(),
+        (TriadQuality::Minor, ChordExtension::Seventh, Some(SeventhQuality::Minor)) => {
+            "m7".to_string()
+        }
+        (TriadQuality::Minor, ChordExtension::Seventh, Some(SeventhQuality::Major)) => {
+            "mMaj7".to_string()
+        }
+        (TriadQuality::Minor, ChordExtension::Ninth, Some(SeventhQuality::Minor)) => {
+            "m9".to_string()
+        }
+        (TriadQuality::Minor, ChordExtension::Ninth, Some(SeventhQuality::Major)) => {
+            "mMaj9".to_string()
+        }
+        (TriadQuality::Minor, ChordExtension::Eleventh, Some(SeventhQuality::Minor)) => {
+            "m11".to_string()
+        }
+        (TriadQuality::Minor, ChordExtension::Eleventh, Some(SeventhQuality::Major)) => {
+            "mMaj11".to_string()
+        }
+        (TriadQuality::Minor, ChordExtension::Thirteenth, Some(SeventhQuality::Minor)) => {
+            "m13".to_string()
+        }
+        (TriadQuality::Minor, ChordExtension::Thirteenth, Some(SeventhQuality::Major)) => {
+            "mMaj13".to_string()
+        }
+        (TriadQuality::Diminished, ChordExtension::Triad, _) => "dim".to_string(),
+        (TriadQuality::Diminished, ChordExtension::Seventh, Some(SeventhQuality::Diminished)) => {
+            "dim7".to_string()
+        }
+        (TriadQuality::Diminished, ChordExtension::Seventh, Some(SeventhQuality::Minor)) => {
+            "m7b5".to_string()
+        }
+        (TriadQuality::Augmented, ChordExtension::Triad, _) => "aug".to_string(),
+        (TriadQuality::Augmented, ChordExtension::Seventh, Some(SeventhQuality::Minor)) => {
+            "aug7".to_string()
+        }
+        (TriadQuality::Augmented, ChordExtension::Seventh, Some(SeventhQuality::Major)) => {
+            "augMaj7".to_string()
+        }
+        _ => unreachable!("validated chord specification"),
+    };
+
+    // Without an explicit major marker, a root-position alteration is
+    // indistinguishable from a root accidental (`C(b5)` would become `Cb5`).
+    if descriptor.is_empty()
+        && spec.suspension().is_none()
+        && matches!(spec.modifiers().first(), Some(ChordModifier::Alter(_)))
+    {
+        descriptor.push_str("maj");
+    }
+
+    if let Some(suspension) = spec.suspension() {
+        descriptor.push_str(match suspension {
+            Suspension::Second => "sus2",
+            Suspension::Fourth => "sus4",
+        });
+    }
+    for modifier in spec.modifiers() {
+        descriptor.push_str(&format_modifier(modifier));
+    }
+    descriptor
 }

--- a/src/chord/errors.rs
+++ b/src/chord/errors.rs
@@ -3,9 +3,21 @@ use std::error;
 use std::fmt;
 
 /// An error while parsing a chord.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ChordError {
     InvalidRegex,
+    EmptySymbol,
+    InvalidRoot { position: usize },
+    UnexpectedToken { position: usize, token: String },
+    InvalidModifier(String),
+    InvalidModifierAt { position: usize, modifier: String },
+    ConflictingModifiers(String),
+    ConflictingModifiersAt { position: usize, message: String },
+    InvalidSlashBass { position: usize },
+    InvalidDegree(u8),
+    InvalidAlteration(i8),
+    InvalidSpecification(String),
+    UnsupportedConstruction { position: usize, message: String },
     UnknownIntervalPattern(Vec<u8>),
     UnsupportedChord(String),
     InvalidInversion(u8),
@@ -15,6 +27,52 @@ impl fmt::Display for ChordError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
             ChordError::InvalidRegex => write!(f, "Invalid Regex!"),
+            ChordError::EmptySymbol => write!(f, "Chord symbol is empty"),
+            ChordError::InvalidRoot { position } => {
+                write!(f, "Invalid chord root at byte {}", position)
+            }
+            ChordError::UnexpectedToken { position, token } => {
+                write!(f, "Unexpected token {:?} at byte {}", token, position)
+            }
+            ChordError::InvalidModifier(modifier) => {
+                write!(f, "Invalid chord modifier: {}", modifier)
+            }
+            ChordError::InvalidModifierAt { position, modifier } => {
+                write!(
+                    f,
+                    "Invalid chord modifier {} at byte {}",
+                    modifier, position
+                )
+            }
+            ChordError::ConflictingModifiers(message) => {
+                write!(f, "Conflicting chord modifiers: {}", message)
+            }
+            ChordError::ConflictingModifiersAt { position, message } => {
+                write!(
+                    f,
+                    "Conflicting chord modifiers at byte {}: {}",
+                    position, message
+                )
+            }
+            ChordError::InvalidSlashBass { position } => {
+                write!(f, "Invalid slash bass at byte {}", position)
+            }
+            ChordError::InvalidDegree(degree) => {
+                write!(f, "Invalid chord degree: {}", degree)
+            }
+            ChordError::InvalidAlteration(alteration) => {
+                write!(f, "Invalid chord alteration: {}", alteration)
+            }
+            ChordError::InvalidSpecification(message) => {
+                write!(f, "Invalid chord specification: {}", message)
+            }
+            ChordError::UnsupportedConstruction { position, message } => {
+                write!(
+                    f,
+                    "Unsupported chord construction at byte {}: {}",
+                    position, message
+                )
+            }
             ChordError::UnknownIntervalPattern(intervals) => {
                 write!(f, "Unknown chord interval pattern: {:?}", intervals)
             }
@@ -29,17 +87,13 @@ impl fmt::Display for ChordError {
 impl error::Error for ChordError {}
 
 impl From<NoteError> for ChordError {
-    fn from(e: NoteError) -> Self {
-        match e {
-            _ => ChordError::InvalidRegex,
-        }
+    fn from(_: NoteError) -> Self {
+        ChordError::InvalidRegex
     }
 }
 
 impl From<regex::Error> for ChordError {
-    fn from(e: regex::Error) -> Self {
-        match e {
-            _ => ChordError::InvalidRegex,
-        }
+    fn from(_: regex::Error) -> Self {
+        ChordError::InvalidRegex
     }
 }

--- a/src/chord/number.rs
+++ b/src/chord/number.rs
@@ -12,6 +12,9 @@ lazy_static! {
                 MajorSeventh,
             ),
             (Regex::new("(?i)^(triad)$").unwrap(), Triad),
+            (Regex::new("(?i)^(fifth|5)$").unwrap(), Fifth),
+            (Regex::new("(?i)^(sixth|6)$").unwrap(), Sixth),
+            (Regex::new("(?i)^(six[- ]?nine|6/9)$").unwrap(), SixNine),
             (Regex::new("(?i)^(seventh|7)$").unwrap(), Seventh),
             (Regex::new("(?i)^(ninth|9)$").unwrap(), Ninth),
             (Regex::new("(?i)^(eleventh|11)$").unwrap(), Eleventh),
@@ -21,9 +24,12 @@ lazy_static! {
 }
 
 /// The superscript number after a chord.
-#[derive(Display, Debug, Clone, Copy, PartialEq)]
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Number {
     Triad,
+    Fifth,
+    Sixth,
+    SixNine,
     Seventh,
     MajorSeventh,
     Ninth,

--- a/src/chord/parser.rs
+++ b/src/chord/parser.rs
@@ -1,0 +1,825 @@
+use crate::chord::{
+    ChordError, ChordExtension, ChordModifier, ChordSpec, ChordTone, SeventhQuality, Suspension,
+    TriadQuality,
+};
+use crate::note::Pitch;
+
+pub(crate) enum ParsedSlash {
+    Bass(Pitch),
+    Inversion { value: u8, position: usize },
+}
+
+pub(crate) struct ParsedChord {
+    pub root: Pitch,
+    pub spec: ChordSpec,
+    pub slash: Option<ParsedSlash>,
+}
+
+#[derive(Clone)]
+struct MappedText {
+    text: String,
+    positions: Vec<usize>,
+    end: usize,
+}
+
+impl MappedText {
+    fn from_source(input: &str, offset: usize) -> Self {
+        let leading = input.len() - input.trim_start().len();
+        let trimmed = input.trim();
+        let mut positions = Vec::with_capacity(trimmed.len());
+        for (position, character) in trimmed.char_indices() {
+            for _ in 0..character.len_utf8() {
+                positions.push(offset + leading + position);
+            }
+        }
+        Self {
+            text: trimmed.to_string(),
+            positions,
+            end: offset + leading + trimmed.len(),
+        }
+    }
+
+    fn position(&self, normalized_offset: usize) -> usize {
+        self.positions
+            .get(normalized_offset)
+            .copied()
+            .unwrap_or(self.end)
+    }
+
+    fn push_replacement(
+        output: &mut String,
+        positions: &mut Vec<usize>,
+        replacement: &str,
+        source_position: usize,
+    ) {
+        output.push_str(replacement);
+        for _ in 0..replacement.len() {
+            positions.push(source_position);
+        }
+    }
+
+    fn map_characters<F>(&self, mut replacement: F) -> Self
+    where
+        F: FnMut(usize, char, &str) -> String,
+    {
+        let mut text = String::new();
+        let mut positions = Vec::new();
+        for (position, character) in self.text.char_indices() {
+            let mapped = replacement(position, character, &self.text[position..]);
+            Self::push_replacement(&mut text, &mut positions, &mapped, self.position(position));
+        }
+        Self {
+            text,
+            positions,
+            end: self.end,
+        }
+    }
+
+    fn replace_all(&self, needle: &str, replacement: &str) -> Self {
+        let mut text = String::new();
+        let mut positions = Vec::new();
+        let mut cursor = 0;
+        while cursor < self.text.len() {
+            if self.text[cursor..].starts_with(needle) {
+                Self::push_replacement(
+                    &mut text,
+                    &mut positions,
+                    replacement,
+                    self.position(cursor),
+                );
+                cursor += needle.len();
+            } else {
+                let character = self.text[cursor..].chars().next().unwrap();
+                let end = cursor + character.len_utf8();
+                text.push(character);
+                positions.extend_from_slice(&self.positions[cursor..end]);
+                cursor = end;
+            }
+        }
+        Self {
+            text,
+            positions,
+            end: self.end,
+        }
+    }
+
+    fn filter_characters<F>(&self, mut keep: F) -> Self
+    where
+        F: FnMut(char) -> bool,
+    {
+        let mut text = String::new();
+        let mut positions = Vec::new();
+        for (position, character) in self.text.char_indices() {
+            if keep(character) {
+                let end = position + character.len_utf8();
+                text.push(character);
+                positions.extend_from_slice(&self.positions[position..end]);
+            }
+        }
+        Self {
+            text,
+            positions,
+            end: self.end,
+        }
+    }
+
+    fn replace_prefix(&self, prefix_len: usize, replacement: &str) -> Self {
+        let mut text = String::new();
+        let mut positions = Vec::new();
+        Self::push_replacement(&mut text, &mut positions, replacement, self.position(0));
+        text.push_str(&self.text[prefix_len..]);
+        positions.extend_from_slice(&self.positions[prefix_len..]);
+        Self {
+            text,
+            positions,
+            end: self.end,
+        }
+    }
+
+    fn slice(&self, start: usize, end: usize) -> Self {
+        Self {
+            text: self.text[start..end].to_string(),
+            positions: self.positions[start..end].to_vec(),
+            end: self.position(end),
+        }
+    }
+
+    fn append_literal(&mut self, literal: &str, source_position: usize) {
+        Self::push_replacement(
+            &mut self.text,
+            &mut self.positions,
+            literal,
+            source_position,
+        );
+    }
+
+    fn append(&mut self, other: &Self) {
+        self.text.push_str(&other.text);
+        self.positions.extend_from_slice(&other.positions);
+        self.end = other.end;
+    }
+}
+
+pub(crate) fn parse_chord(input: &str) -> Result<ParsedChord, ChordError> {
+    let input = input.trim();
+    if input.is_empty() {
+        return Err(ChordError::EmptySymbol);
+    }
+
+    let lowercase = input.to_lowercase();
+    if lowercase.contains("half") && lowercase.contains("diminished") && lowercase.contains("triad")
+    {
+        return Err(ChordError::UnsupportedConstruction {
+            position: lowercase.find("half").unwrap_or(0),
+            message: "half-diminished describes a seventh chord, not a triad".to_string(),
+        });
+    }
+
+    let (root, root_end) = parse_root(input)?;
+    let source_descriptor = &input[root_end..];
+    validate_parentheses(source_descriptor, root_end)?;
+
+    let normalized = normalize_descriptor_mapped(source_descriptor, root_end);
+    let (descriptor, slash_text) = split_slash(&normalized)?;
+    let spec = parse_descriptor(&descriptor, root_end)?;
+    let slash = match slash_text {
+        None => None,
+        Some(text) => {
+            let position = text.position(0);
+            if text.text.is_empty() {
+                return Err(ChordError::InvalidSlashBass { position });
+            }
+            if text
+                .text
+                .chars()
+                .all(|character| character.is_ascii_digit())
+            {
+                let inversion = text
+                    .text
+                    .parse::<u8>()
+                    .map_err(|_| ChordError::InvalidSlashBass { position })?;
+                Some(ParsedSlash::Inversion {
+                    value: inversion,
+                    position,
+                })
+            } else {
+                let bass =
+                    Pitch::from_str(&text.text).ok_or(ChordError::InvalidSlashBass { position })?;
+                Some(ParsedSlash::Bass(bass))
+            }
+        }
+    };
+
+    Ok(ParsedChord { root, spec, slash })
+}
+
+fn validate_parentheses(input: &str, offset: usize) -> Result<(), ChordError> {
+    let mut opening = None;
+    let characters: Vec<(usize, char)> = input.char_indices().collect();
+    for (index, (position, character)) in characters.iter().enumerate() {
+        if *character != ',' {
+            continue;
+        }
+
+        let previous = characters[..index]
+            .iter()
+            .rev()
+            .find(|(_, character)| !character.is_whitespace())
+            .map(|(_, character)| *character);
+        let next = characters[index + 1..]
+            .iter()
+            .find(|(_, character)| !character.is_whitespace())
+            .map(|(_, character)| *character);
+        if matches!(previous, None | Some('(' | ','))
+            || matches!(next, None | Some(')' | ',' | '/'))
+        {
+            return Err(ChordError::UnexpectedToken {
+                position: offset + position,
+                token: ",".to_string(),
+            });
+        }
+    }
+
+    for (position, character) in input.char_indices() {
+        match character {
+            '(' if opening.is_none() => opening = Some(position),
+            '(' => {
+                return Err(ChordError::UnexpectedToken {
+                    position: offset + position,
+                    token: "(".to_string(),
+                })
+            }
+            ')' => match opening.take() {
+                None => {
+                    return Err(ChordError::UnexpectedToken {
+                        position: offset + position,
+                        token: ")".to_string(),
+                    })
+                }
+                Some(start)
+                    if input[start + 1..position]
+                        .chars()
+                        .all(|character| character.is_whitespace() || character == ',') =>
+                {
+                    return Err(ChordError::UnexpectedToken {
+                        position: offset + start,
+                        token: "()".to_string(),
+                    })
+                }
+                Some(_) => {}
+            },
+            _ => {}
+        }
+    }
+    if let Some(position) = opening {
+        return Err(ChordError::UnexpectedToken {
+            position: offset + position,
+            token: "(".to_string(),
+        });
+    }
+    Ok(())
+}
+
+fn parse_root(input: &str) -> Result<(Pitch, usize), ChordError> {
+    let mut characters = input.char_indices();
+    let (_, first) = characters
+        .next()
+        .ok_or(ChordError::InvalidRoot { position: 0 })?;
+    if !matches!(first, 'A'..='G' | 'a'..='g') {
+        return Err(ChordError::InvalidRoot { position: 0 });
+    }
+
+    let mut end = first.len_utf8();
+    for (index, character) in characters {
+        let is_sus_start = matches!(character, 's' | 'S')
+            && input[index + character.len_utf8()..]
+                .to_ascii_lowercase()
+                .starts_with("us");
+        if is_sus_start {
+            break;
+        }
+        if matches!(
+            character,
+            'b' | '♭' | '𝄫' | '#' | '♯' | 's' | 'S' | '𝄪' | 'x'
+        ) {
+            end = index + character.len_utf8();
+        } else {
+            break;
+        }
+    }
+
+    Pitch::from_str(&input[..end])
+        .map(|pitch| (pitch, end))
+        .ok_or(ChordError::InvalidRoot { position: 0 })
+}
+
+fn normalize_descriptor_mapped(input: &str, offset: usize) -> MappedText {
+    let mut text = MappedText::from_source(input, offset);
+    text = text.map_characters(|_, character, tail| {
+        let lowercase_tail = tail.to_ascii_lowercase();
+        let starts_long_quality = lowercase_tail.starts_with("maj")
+            || lowercase_tail.starts_with("major")
+            || lowercase_tail.starts_with("min")
+            || lowercase_tail.starts_with("minor");
+        if character == 'M' && !starts_long_quality {
+            "maj".to_string()
+        } else {
+            character.to_string()
+        }
+    });
+    text = expand_delta_aliases_mapped(&text);
+    text = text.map_characters(|_, character, _| match character {
+        'Δ' | '∆' | '^' => "maj".to_string(),
+        'ø' | 'Ø' => "halfdim".to_string(),
+        '°' | 'º' => "dim".to_string(),
+        '♭' => "b".to_string(),
+        '♯' => "#".to_string(),
+        _ => character.to_lowercase().collect(),
+    });
+    for (long, short) in [
+        ("half diminished", "halfdim"),
+        ("half-diminished", "halfdim"),
+        ("halfdiminished", "halfdim"),
+        ("major", "maj"),
+        ("minor", "m"),
+        ("diminished", "dim"),
+        ("augmented", "aug"),
+        ("dominant", "dom"),
+        ("suspended", "sus"),
+        ("thirteenth", "13"),
+        ("eleventh", "11"),
+        ("ninth", "9"),
+        ("seventh", "7"),
+        ("sixth", "6"),
+        ("fifth", "5"),
+        ("triad", ""),
+    ] {
+        text = text.replace_all(long, short);
+    }
+    text = text.filter_characters(|character| {
+        !character.is_whitespace() && !matches!(character, '(' | ')' | ',')
+    });
+    text = text
+        .replace_all("m/maj", "mmaj")
+        .replace_all("m/ma", "mmaj")
+        .replace_all("6/9", "6_9");
+
+    let slash = text.text.find('/');
+    let (core, bass, slash_position) = match slash {
+        Some(position) => (
+            text.slice(0, position),
+            Some(text.slice(position + 1, text.text.len())),
+            Some(text.position(position)),
+        ),
+        None => (text.clone(), None, None),
+    };
+    let mut core = normalize_core_alias_mapped(core).replace_all("6_9", "6/9");
+    if let (Some(bass), Some(slash_position)) = (bass, slash_position) {
+        core.append_literal("/", slash_position);
+        core.append(&bass);
+    }
+    core
+}
+
+fn expand_delta_aliases_mapped(input: &MappedText) -> MappedText {
+    input.map_characters(|_, character, tail| {
+        if !matches!(character, 'Δ' | '∆') {
+            return character.to_string();
+        }
+        let tail = &tail[character.len_utf8()..];
+        let trimmed = tail.trim_start();
+        let has_explicit_extension = ["6", "7", "9", "11", "13"]
+            .iter()
+            .any(|extension| trimmed.starts_with(extension));
+        if has_explicit_extension {
+            "maj".to_string()
+        } else {
+            "maj7".to_string()
+        }
+    })
+}
+
+fn normalize_core_alias_mapped(mut core: MappedText) -> MappedText {
+    if core.text.starts_with('-') {
+        core = core.replace_prefix(1, "m");
+    } else if core.text.starts_with('+') {
+        core = core.replace_prefix(1, "aug");
+    } else if core.text == "o" || core.text.starts_with("o7") {
+        core = core.replace_prefix(1, "dim");
+    }
+
+    if core.text == "0" || core.text == "07" {
+        return core.replace_prefix(1, "dim");
+    }
+    if core.text == "h" || core.text == "h7" {
+        let len = core.text.len();
+        return core.replace_prefix(len, "halfdim7");
+    }
+    if core.text.starts_with("m7b5") {
+        return core.replace_prefix(4, "halfdim7");
+    }
+    if core.text.starts_with("mi") && !core.text.starts_with("min") {
+        core = core.replace_prefix(2, "m");
+    } else if core
+        .text
+        .strip_prefix("ma")
+        .map(|rest| matches!(rest, "7" | "9" | "11" | "13"))
+        .unwrap_or(false)
+    {
+        core = core.replace_prefix(2, "maj");
+    }
+
+    for (alias, canonical) in [
+        ("maj6add9", "6/9"),
+        ("m6add9", "m6/9"),
+        ("6add9", "6/9"),
+        ("maj69", "6/9"),
+        ("m69", "m6/9"),
+        ("69", "6/9"),
+    ] {
+        if core.text.starts_with(alias) {
+            return core.replace_prefix(alias.len(), canonical);
+        }
+    }
+
+    match core.text.as_str() {
+        "2" => core.replace_prefix(1, "add2"),
+        "4" => core.replace_prefix(1, "add4"),
+        "alt7" => core.replace_prefix(4, "7alt"),
+        "7+" | "7aug" => {
+            let len = core.text.len();
+            core.replace_prefix(len, "aug7")
+        }
+        _ => core,
+    }
+}
+
+fn split_slash(descriptor: &MappedText) -> Result<(MappedText, Option<MappedText>), ChordError> {
+    let protected = descriptor.replace_all("6/9", "6_9");
+    let mut slashes = protected
+        .text
+        .match_indices('/')
+        .map(|(position, _)| position);
+    let first = slashes.next();
+    if slashes.next().is_some() {
+        return Err(ChordError::InvalidSlashBass {
+            position: protected.position(first.unwrap() + 1),
+        });
+    }
+    match first {
+        Some(position) => Ok((
+            protected.slice(0, position).replace_all("6_9", "6/9"),
+            Some(protected.slice(position + 1, protected.text.len())),
+        )),
+        None => Ok((protected.replace_all("6_9", "6/9"), None)),
+    }
+}
+
+fn parse_descriptor(descriptor: &MappedText, root_offset: usize) -> Result<ChordSpec, ChordError> {
+    let mut rest = descriptor.text.as_str();
+    let mut suspension = None;
+
+    if let Some((parsed, remaining)) = take_suspension(rest) {
+        suspension = Some(parsed);
+        rest = remaining;
+    }
+
+    let mut triad_quality = TriadQuality::Major;
+    let mut explicit_major = false;
+    let mut explicit_dominant = false;
+    let mut half_diminished = false;
+    let mut major_seventh_marker = false;
+
+    if let Some(remaining) = rest.strip_prefix("halfdim") {
+        triad_quality = TriadQuality::Diminished;
+        half_diminished = true;
+        rest = remaining;
+    } else if let Some(remaining) = rest.strip_prefix("mmaj") {
+        triad_quality = TriadQuality::Minor;
+        major_seventh_marker = true;
+        rest = remaining;
+    } else if let Some(remaining) = rest.strip_prefix("maj") {
+        triad_quality = TriadQuality::Major;
+        explicit_major = true;
+        major_seventh_marker = true;
+        rest = remaining;
+    } else if let Some(remaining) = rest.strip_prefix("min") {
+        triad_quality = TriadQuality::Minor;
+        rest = remaining;
+    } else if let Some(remaining) = rest.strip_prefix('m') {
+        triad_quality = TriadQuality::Minor;
+        rest = remaining;
+    } else if let Some(remaining) = rest.strip_prefix("dim") {
+        triad_quality = TriadQuality::Diminished;
+        rest = remaining;
+    } else if let Some(remaining) = rest.strip_prefix("aug") {
+        triad_quality = TriadQuality::Augmented;
+        rest = remaining;
+        if let Some(remaining) = rest.strip_prefix("maj") {
+            major_seventh_marker = true;
+            rest = remaining;
+        }
+    } else if let Some(remaining) = rest.strip_prefix("dom") {
+        explicit_dominant = true;
+        rest = remaining;
+    }
+
+    if suspension.is_none() {
+        if let Some((parsed, remaining)) = take_suspension(rest) {
+            suspension = Some(parsed);
+            rest = remaining;
+        }
+    }
+
+    let explicit_fifth = rest.starts_with('5');
+    let (mut extension, remaining) = take_extension(rest);
+    rest = remaining;
+
+    if suspension.is_none() {
+        if let Some((parsed, remaining)) = take_suspension(rest) {
+            suspension = Some(parsed);
+            rest = remaining;
+        }
+    }
+
+    if extension.is_none() && (half_diminished || explicit_dominant || rest.starts_with("alt")) {
+        extension = Some(ChordExtension::Seventh);
+    }
+
+    if explicit_fifth {
+        if explicit_major
+            || explicit_dominant
+            || half_diminished
+            || major_seventh_marker
+            || triad_quality != TriadQuality::Major
+        {
+            return Err(ChordError::UnsupportedConstruction {
+                position: root_offset,
+                message: "the fifth marker cannot be combined with another chord quality"
+                    .to_string(),
+            });
+        }
+        triad_quality = TriadQuality::Power;
+    }
+
+    let extension = extension.unwrap_or(ChordExtension::Triad);
+    let uses_seventh = matches!(
+        extension,
+        ChordExtension::Seventh
+            | ChordExtension::Ninth
+            | ChordExtension::Eleventh
+            | ChordExtension::Thirteenth
+    );
+    if major_seventh_marker && triad_quality != TriadQuality::Major && !uses_seventh {
+        return Err(ChordError::UnsupportedConstruction {
+            position: root_offset,
+            message: "minor-major and augmented-major qualities require a seventh or extension"
+                .to_string(),
+        });
+    }
+    if explicit_dominant && !uses_seventh {
+        return Err(ChordError::UnsupportedConstruction {
+            position: root_offset,
+            message: "dominant quality requires a seventh or extension".to_string(),
+        });
+    }
+    let seventh_quality = if matches!(
+        extension,
+        ChordExtension::Seventh
+            | ChordExtension::Ninth
+            | ChordExtension::Eleventh
+            | ChordExtension::Thirteenth
+    ) {
+        Some(if half_diminished {
+            SeventhQuality::Minor
+        } else if major_seventh_marker || explicit_major {
+            SeventhQuality::Major
+        } else {
+            match triad_quality {
+                TriadQuality::Diminished => SeventhQuality::Diminished,
+                _ => SeventhQuality::Minor,
+            }
+        })
+    } else {
+        None
+    };
+
+    let mut modifiers = Vec::new();
+    let mut modifier_offsets = Vec::new();
+    let mut consumed = descriptor.text.len() - rest.len();
+    while !rest.is_empty() {
+        if let Some((parsed, remaining)) = take_suspension(rest) {
+            if suspension.replace(parsed).is_some() {
+                return Err(ChordError::ConflictingModifiersAt {
+                    position: descriptor.position(consumed),
+                    message: "a chord cannot contain two suspensions".to_string(),
+                });
+            }
+            consumed += rest.len() - remaining.len();
+            rest = remaining;
+            continue;
+        }
+        if let Some(remaining) = rest.strip_prefix("alt") {
+            push_modifier(
+                &mut modifiers,
+                &mut modifier_offsets,
+                ChordModifier::Altered,
+                consumed,
+                descriptor,
+            )?;
+            consumed += 3;
+            rest = remaining;
+            continue;
+        }
+        if let Some(remaining) = rest.strip_prefix("add") {
+            let (tone, remaining) =
+                take_tone(remaining, true).ok_or_else(|| ChordError::UnexpectedToken {
+                    position: descriptor.position(consumed),
+                    token: rest.to_string(),
+                })?;
+            push_modifier(
+                &mut modifiers,
+                &mut modifier_offsets,
+                ChordModifier::Add(tone),
+                consumed,
+                descriptor,
+            )?;
+            consumed += rest.len() - remaining.len();
+            rest = remaining;
+            continue;
+        }
+        if let Some(remaining) = rest
+            .strip_prefix("omit")
+            .or_else(|| rest.strip_prefix("no"))
+        {
+            let (degree, remaining) =
+                take_degree(remaining).ok_or_else(|| ChordError::UnexpectedToken {
+                    position: descriptor.position(consumed),
+                    token: rest.to_string(),
+                })?;
+            push_modifier(
+                &mut modifiers,
+                &mut modifier_offsets,
+                ChordModifier::Omit(degree),
+                consumed,
+                descriptor,
+            )?;
+            consumed += rest.len() - remaining.len();
+            rest = remaining;
+            continue;
+        }
+        if rest.starts_with('b') || rest.starts_with('#') {
+            let (tone, remaining) =
+                take_tone(rest, false).ok_or_else(|| ChordError::UnexpectedToken {
+                    position: descriptor.position(consumed),
+                    token: rest.to_string(),
+                })?;
+            push_modifier(
+                &mut modifiers,
+                &mut modifier_offsets,
+                ChordModifier::Alter(tone),
+                consumed,
+                descriptor,
+            )?;
+            consumed += rest.len() - remaining.len();
+            rest = remaining;
+            continue;
+        }
+
+        return Err(ChordError::UnexpectedToken {
+            position: descriptor.position(consumed),
+            token: rest.to_string(),
+        });
+    }
+
+    let modifier_error_position = modifier_offsets
+        .last()
+        .map(|position| descriptor.position(*position))
+        .unwrap_or(root_offset);
+    ChordSpec::from_parts(
+        triad_quality,
+        seventh_quality,
+        extension,
+        suspension,
+        modifiers,
+    )
+    .map_err(|error| match error {
+        ChordError::InvalidModifier(modifier) => ChordError::InvalidModifierAt {
+            position: modifier_error_position,
+            modifier,
+        },
+        ChordError::ConflictingModifiers(message) => ChordError::ConflictingModifiersAt {
+            position: modifier_error_position,
+            message,
+        },
+        ChordError::InvalidSpecification(message) => ChordError::UnsupportedConstruction {
+            position: root_offset,
+            message,
+        },
+        error => error,
+    })
+}
+
+fn push_modifier(
+    modifiers: &mut Vec<ChordModifier>,
+    offsets: &mut Vec<usize>,
+    modifier: ChordModifier,
+    normalized_offset: usize,
+    descriptor: &MappedText,
+) -> Result<(), ChordError> {
+    let position = descriptor.position(normalized_offset);
+    if modifiers.iter().any(|existing| existing == &modifier) {
+        return Err(ChordError::ConflictingModifiersAt {
+            position,
+            message: "duplicate modifier".to_string(),
+        });
+    }
+    if modifiers.iter().any(|existing| {
+        parser_modifier_degree(existing).is_some()
+            && parser_modifier_degree(existing) == parser_modifier_degree(&modifier)
+    }) {
+        return Err(ChordError::ConflictingModifiersAt {
+            position,
+            message: "multiple operations target the same degree".to_string(),
+        });
+    }
+    if matches!(modifier, ChordModifier::Altered) && !modifiers.is_empty()
+        || modifiers
+            .iter()
+            .any(|existing| matches!(existing, ChordModifier::Altered))
+    {
+        return Err(ChordError::ConflictingModifiersAt {
+            position,
+            message: "alt cannot be combined with another modifier".to_string(),
+        });
+    }
+    modifiers.push(modifier);
+    offsets.push(normalized_offset);
+    Ok(())
+}
+
+fn parser_modifier_degree(modifier: &ChordModifier) -> Option<u8> {
+    match modifier {
+        ChordModifier::Add(tone) | ChordModifier::Alter(tone) => Some(tone.degree()),
+        ChordModifier::Omit(degree) => Some(*degree),
+        ChordModifier::Altered => None,
+    }
+}
+
+fn take_extension(input: &str) -> (Option<ChordExtension>, &str) {
+    for (token, extension) in [
+        ("6/9", ChordExtension::SixNine),
+        ("13", ChordExtension::Thirteenth),
+        ("11", ChordExtension::Eleventh),
+        ("9", ChordExtension::Ninth),
+        ("7", ChordExtension::Seventh),
+        ("6", ChordExtension::Sixth),
+        ("5", ChordExtension::Triad),
+    ] {
+        if let Some(remaining) = input.strip_prefix(token) {
+            return (Some(extension), remaining);
+        }
+    }
+    (None, input)
+}
+
+fn take_suspension(input: &str) -> Option<(Suspension, &str)> {
+    if let Some(remaining) = input.strip_prefix("sus2") {
+        Some((Suspension::Second, remaining))
+    } else if let Some(remaining) = input.strip_prefix("sus4") {
+        Some((Suspension::Fourth, remaining))
+    } else {
+        input
+            .strip_prefix("sus")
+            .map(|remaining| (Suspension::Fourth, remaining))
+    }
+}
+
+fn take_tone(input: &str, alteration_optional: bool) -> Option<(ChordTone, &str)> {
+    let mut alteration: i8 = 0;
+    let mut rest = input;
+    while let Some(remaining) = rest.strip_prefix('b') {
+        alteration = alteration.checked_sub(1)?;
+        rest = remaining;
+    }
+    while let Some(remaining) = rest.strip_prefix('#') {
+        alteration = alteration.checked_add(1)?;
+        rest = remaining;
+    }
+    if alteration == 0 && !alteration_optional {
+        return None;
+    }
+    let (degree, remaining) = take_degree(rest)?;
+    let tone = ChordTone::new(degree, alteration).ok()?;
+    Some((tone, remaining))
+}
+
+fn take_degree(input: &str) -> Option<(u8, &str)> {
+    for degree in [13u8, 11, 9, 7, 6, 5, 4, 3, 2, 1] {
+        let token = degree.to_string();
+        if let Some(remaining) = input.strip_prefix(&token) {
+            return Some((degree, remaining));
+        }
+    }
+    None
+}

--- a/src/chord/quality.rs
+++ b/src/chord/quality.rs
@@ -8,14 +8,8 @@ lazy_static! {
         use Quality::*;
 
         vec![
-            (
-                Regex::new(r"^(m\s+|m$|(?i:min(?:or)?))").unwrap(),
-                Minor,
-            ),
-            (
-                Regex::new(r"^(M\s+|M$|(?i:maj(?:or)?))").unwrap(),
-                Major,
-            ),
+            (Regex::new(r"^(m\s+|m$|(?i:min(?:or)?))").unwrap(), Minor),
+            (Regex::new(r"^(M\s+|M$|(?i:maj(?:or)?))").unwrap(), Major),
             (
                 Regex::new(r"(?i)^(half\s*diminished|halfdiminished|halfdim)").unwrap(),
                 HalfDiminished,
@@ -31,12 +25,13 @@ lazy_static! {
                 Regex::new(r"(?i)^(sus4\s+|sus4$|suspended4)").unwrap(),
                 Suspended4,
             ),
+            (Regex::new(r"(?i)^(power|power\s*chord)$").unwrap(), Power),
         ]
     };
 }
 
 /// The quality of a chord.
-#[derive(Display, Debug, Clone, Copy, PartialEq)]
+#[derive(Display, Debug, Clone, Copy, PartialEq, Eq, Hash)]
 pub enum Quality {
     Major,
     Minor,
@@ -46,6 +41,7 @@ pub enum Quality {
     Dominant,
     Suspended2,
     Suspended4,
+    Power,
 }
 
 impl Quality {

--- a/src/chord/spec.rs
+++ b/src/chord/spec.rs
@@ -1,0 +1,511 @@
+use crate::chord::ChordError;
+
+/// The quality of the chord's base triad before extensions and modifiers.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TriadQuality {
+    Major,
+    Minor,
+    Diminished,
+    Augmented,
+    Power,
+}
+
+/// The quality of the seventh used by seventh and extended chords.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum SeventhQuality {
+    Major,
+    Minor,
+    Diminished,
+}
+
+/// The highest structural extension of a chord.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum ChordExtension {
+    Triad,
+    Sixth,
+    SixNine,
+    Seventh,
+    Ninth,
+    Eleventh,
+    Thirteenth,
+}
+
+/// A suspension replacing the chord's third.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum Suspension {
+    Second,
+    Fourth,
+}
+
+/// A written chord tone represented by its compound degree and alteration.
+///
+/// `degree = 9, alteration = -1` represents a flat ninth. Alterations are
+/// measured in semitones relative to the major/perfect form of the degree.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ChordTone {
+    degree: u8,
+    alteration: i8,
+}
+
+impl ChordTone {
+    pub fn new(degree: u8, alteration: i8) -> Result<Self, ChordError> {
+        if !matches!(degree, 1 | 2 | 3 | 4 | 5 | 6 | 7 | 9 | 11 | 13) {
+            return Err(ChordError::InvalidDegree(degree));
+        }
+        if !(-2..=2).contains(&alteration) {
+            return Err(ChordError::InvalidAlteration(alteration));
+        }
+        Ok(Self { degree, alteration })
+    }
+
+    pub(crate) const fn new_unchecked(degree: u8, alteration: i8) -> Self {
+        Self { degree, alteration }
+    }
+
+    pub fn degree(self) -> u8 {
+        self.degree
+    }
+
+    pub fn alteration(self) -> i8 {
+        self.alteration
+    }
+
+    pub fn semitones(self) -> i16 {
+        let natural = match self.degree {
+            1 => 0,
+            2 => 2,
+            3 => 4,
+            4 => 5,
+            5 => 7,
+            6 => 9,
+            7 => 11,
+            9 => 14,
+            11 => 17,
+            13 => 21,
+            _ => unreachable!("validated chord degree"),
+        };
+        natural + self.alteration as i16
+    }
+
+    pub fn letter_offset(self) -> i16 {
+        (self.degree as i16 - 1) % 7
+    }
+
+    pub(crate) fn accidental_prefix(self) -> String {
+        let accidental = if self.alteration < 0 { 'b' } else { '#' };
+        (0..self.alteration.unsigned_abs())
+            .map(|_| accidental)
+            .collect()
+    }
+}
+
+/// A modification applied to a base chord formula.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub enum ChordModifier {
+    Add(ChordTone),
+    Alter(ChordTone),
+    Omit(u8),
+    Altered,
+}
+
+/// A normalized, validated chord description independent of root and voicing.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ChordSpec {
+    triad_quality: TriadQuality,
+    seventh_quality: Option<SeventhQuality>,
+    extension: ChordExtension,
+    suspension: Option<Suspension>,
+    modifiers: Vec<ChordModifier>,
+}
+
+impl ChordSpec {
+    pub fn new(
+        triad_quality: TriadQuality,
+        seventh_quality: Option<SeventhQuality>,
+        extension: ChordExtension,
+    ) -> Result<Self, ChordError> {
+        let spec = Self {
+            triad_quality,
+            seventh_quality,
+            extension,
+            suspension: None,
+            modifiers: Vec::new(),
+        };
+        spec.validate()?;
+        Ok(spec)
+    }
+
+    pub(crate) fn from_parts(
+        triad_quality: TriadQuality,
+        seventh_quality: Option<SeventhQuality>,
+        extension: ChordExtension,
+        suspension: Option<Suspension>,
+        modifiers: Vec<ChordModifier>,
+    ) -> Result<Self, ChordError> {
+        let mut spec = Self {
+            triad_quality,
+            seventh_quality,
+            extension,
+            suspension,
+            modifiers,
+        };
+        spec.normalize_equivalent_constructions();
+        spec.normalize_modifiers();
+        spec.validate()?;
+        spec.formula()?;
+        Ok(spec)
+    }
+
+    pub fn triad_quality(&self) -> TriadQuality {
+        self.triad_quality
+    }
+
+    pub fn seventh_quality(&self) -> Option<SeventhQuality> {
+        self.seventh_quality
+    }
+
+    pub fn extension(&self) -> ChordExtension {
+        self.extension
+    }
+
+    pub fn suspension(&self) -> Option<Suspension> {
+        self.suspension
+    }
+
+    pub fn modifiers(&self) -> &[ChordModifier] {
+        &self.modifiers
+    }
+
+    fn normalize_modifiers(&mut self) {
+        self.modifiers.sort_by_key(modifier_sort_key);
+    }
+
+    fn normalize_equivalent_constructions(&mut self) {
+        if self.extension == ChordExtension::Sixth {
+            if let Some(index) = self.modifiers.iter().position(|modifier| {
+                matches!(modifier, ChordModifier::Add(tone) if tone.degree == 9 && tone.alteration == 0)
+            }) {
+                self.extension = ChordExtension::SixNine;
+                self.modifiers.remove(index);
+            }
+        }
+
+        if self.triad_quality == TriadQuality::Minor
+            && self.extension == ChordExtension::Seventh
+            && self.seventh_quality == Some(SeventhQuality::Minor)
+        {
+            if let Some(index) = self.modifiers.iter().position(|modifier| {
+                matches!(modifier, ChordModifier::Alter(tone) if tone.degree == 5 && tone.alteration == -1)
+            }) {
+                self.triad_quality = TriadQuality::Diminished;
+                self.modifiers.remove(index);
+            }
+        }
+    }
+
+    fn validate(&self) -> Result<(), ChordError> {
+        use ChordExtension::*;
+
+        let needs_seventh = matches!(self.extension, Seventh | Ninth | Eleventh | Thirteenth);
+        if needs_seventh != self.seventh_quality.is_some() {
+            return Err(ChordError::InvalidSpecification(
+                "seventh and extended chords require exactly one seventh quality".to_string(),
+            ));
+        }
+
+        if self.triad_quality == TriadQuality::Power
+            && (self.extension != Triad
+                || self.seventh_quality.is_some()
+                || self.suspension.is_some()
+                || !self.modifiers.is_empty())
+        {
+            return Err(ChordError::InvalidSpecification(
+                "power chords cannot have extensions or modifiers".to_string(),
+            ));
+        }
+
+        if matches!(self.extension, Sixth | SixNine)
+            && !matches!(
+                self.triad_quality,
+                TriadQuality::Major | TriadQuality::Minor
+            )
+        {
+            return Err(ChordError::InvalidSpecification(
+                "sixth chords require a major or minor triad".to_string(),
+            ));
+        }
+
+        if self.triad_quality == TriadQuality::Diminished
+            && !matches!(self.extension, Triad | Seventh)
+        {
+            return Err(ChordError::InvalidSpecification(
+                "diminished chords support triad and seventh forms".to_string(),
+            ));
+        }
+
+        if needs_seventh {
+            let seventh = self.seventh_quality.unwrap();
+            let compatible = match self.triad_quality {
+                TriadQuality::Diminished => {
+                    matches!(seventh, SeventhQuality::Minor | SeventhQuality::Diminished)
+                }
+                TriadQuality::Major | TriadQuality::Minor | TriadQuality::Augmented => {
+                    matches!(seventh, SeventhQuality::Major | SeventhQuality::Minor)
+                }
+                TriadQuality::Power => false,
+            };
+            if !compatible {
+                return Err(ChordError::InvalidSpecification(
+                    "seventh quality is incompatible with the base triad".to_string(),
+                ));
+            }
+        }
+
+        if self.triad_quality == TriadQuality::Augmented
+            && !matches!(self.extension, Triad | Seventh)
+        {
+            return Err(ChordError::InvalidSpecification(
+                "augmented chords support triad and seventh forms".to_string(),
+            ));
+        }
+
+        if self.suspension.is_some()
+            && !matches!(
+                self.triad_quality,
+                TriadQuality::Major | TriadQuality::Minor
+            )
+        {
+            return Err(ChordError::InvalidSpecification(
+                "suspensions require a major or minor base".to_string(),
+            ));
+        }
+
+        let altered_count = self
+            .modifiers
+            .iter()
+            .filter(|modifier| matches!(modifier, ChordModifier::Altered))
+            .count();
+        if altered_count > 0 {
+            if altered_count != 1
+                || self.modifiers.len() != 1
+                || self.triad_quality != TriadQuality::Major
+                || self.extension != Seventh
+                || self.seventh_quality != Some(SeventhQuality::Minor)
+                || self.suspension.is_some()
+            {
+                return Err(ChordError::ConflictingModifiers(
+                    "alt is only valid by itself on a dominant seventh chord".to_string(),
+                ));
+            }
+            return Ok(());
+        }
+
+        if self.suspension.is_some()
+            && self
+                .modifiers
+                .iter()
+                .any(|modifier| matches!(modifier, ChordModifier::Omit(3)))
+        {
+            return Err(ChordError::ConflictingModifiers(
+                "a suspended chord already omits the third".to_string(),
+            ));
+        }
+
+        for (index, modifier) in self.modifiers.iter().enumerate() {
+            validate_modifier(modifier)?;
+            for other in self.modifiers.iter().skip(index + 1) {
+                if modifier == other {
+                    return Err(ChordError::ConflictingModifiers(format!(
+                        "duplicate modifier {}",
+                        format_modifier(modifier)
+                    )));
+                }
+                if modifier_degree(modifier).is_some()
+                    && modifier_degree(modifier) == modifier_degree(other)
+                {
+                    return Err(ChordError::ConflictingModifiers(format!(
+                        "multiple operations target degree {}",
+                        modifier_degree(modifier).unwrap()
+                    )));
+                }
+            }
+        }
+
+        Ok(())
+    }
+
+    pub fn formula(&self) -> Result<ChordFormula, ChordError> {
+        use ChordExtension::*;
+
+        if self.modifiers == [ChordModifier::Altered] {
+            return Ok(ChordFormula::new(vec![
+                tone(1, 0),
+                tone(3, 0),
+                tone(5, -1),
+                tone(5, 1),
+                tone(7, -1),
+                tone(9, -1),
+                tone(9, 1),
+            ]));
+        }
+
+        let mut tones = match self.triad_quality {
+            TriadQuality::Major => vec![tone(1, 0), tone(3, 0), tone(5, 0)],
+            TriadQuality::Minor => vec![tone(1, 0), tone(3, -1), tone(5, 0)],
+            TriadQuality::Diminished => vec![tone(1, 0), tone(3, -1), tone(5, -1)],
+            TriadQuality::Augmented => vec![tone(1, 0), tone(3, 0), tone(5, 1)],
+            TriadQuality::Power => vec![tone(1, 0), tone(5, 0)],
+        };
+
+        match self.extension {
+            Triad => {}
+            Sixth => tones.push(tone(6, 0)),
+            SixNine => {
+                tones.push(tone(6, 0));
+                tones.push(tone(9, 0));
+            }
+            Seventh | Ninth | Eleventh | Thirteenth => {
+                tones.push(match self.seventh_quality.unwrap() {
+                    SeventhQuality::Major => tone(7, 0),
+                    SeventhQuality::Minor => tone(7, -1),
+                    SeventhQuality::Diminished => tone(7, -2),
+                });
+                if matches!(self.extension, Ninth | Eleventh | Thirteenth) {
+                    tones.push(tone(9, 0));
+                }
+                if matches!(self.extension, Eleventh | Thirteenth) {
+                    tones.push(tone(11, 0));
+                }
+                if self.extension == Thirteenth {
+                    tones.push(tone(13, 0));
+                }
+            }
+        }
+
+        if let Some(suspension) = self.suspension {
+            tones.retain(|tone| tone.degree != 3);
+            tones.push(match suspension {
+                Suspension::Second => tone(2, 0),
+                Suspension::Fourth => tone(4, 0),
+            });
+        }
+
+        for modifier in &self.modifiers {
+            match modifier {
+                ChordModifier::Alter(altered) => {
+                    if tones.iter().any(|tone| {
+                        tone.degree == altered.degree && tone.alteration == altered.alteration
+                    }) {
+                        return Err(ChordError::ConflictingModifiers(format!(
+                            "degree {} already has the requested alteration",
+                            altered.degree
+                        )));
+                    }
+                    tones.retain(|tone| tone.degree != altered.degree);
+                    tones.push(*altered);
+                }
+                ChordModifier::Add(added) => {
+                    if tones.iter().any(|tone| tone.degree == added.degree) {
+                        return Err(ChordError::ConflictingModifiers(format!(
+                            "degree {} is already present",
+                            added.degree
+                        )));
+                    }
+                    tones.push(*added);
+                }
+                ChordModifier::Omit(degree) => {
+                    let previous_len = tones.len();
+                    tones.retain(|tone| tone.degree != *degree);
+                    if tones.len() == previous_len {
+                        return Err(ChordError::ConflictingModifiers(format!(
+                            "degree {} is not present",
+                            degree
+                        )));
+                    }
+                }
+                ChordModifier::Altered => unreachable!("handled above"),
+            }
+        }
+
+        if tones.len() < 2 {
+            return Err(ChordError::InvalidSpecification(
+                "a chord must contain at least two tones".to_string(),
+            ));
+        }
+
+        Ok(ChordFormula::new(tones))
+    }
+}
+
+/// The resolved tones of a chord, sorted in written degree order.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct ChordFormula {
+    tones: Vec<ChordTone>,
+}
+
+impl ChordFormula {
+    fn new(mut tones: Vec<ChordTone>) -> Self {
+        tones.sort_by_key(|tone| (tone.degree, tone.alteration));
+        Self { tones }
+    }
+
+    pub fn tones(&self) -> &[ChordTone] {
+        &self.tones
+    }
+}
+
+pub(crate) fn format_modifier(modifier: &ChordModifier) -> String {
+    match modifier {
+        ChordModifier::Add(tone) => {
+            format!("add{}{}", tone.accidental_prefix(), tone.degree)
+        }
+        ChordModifier::Alter(tone) => {
+            format!("{}{}", tone.accidental_prefix(), tone.degree)
+        }
+        ChordModifier::Omit(degree) => format!("no{}", degree),
+        ChordModifier::Altered => "alt".to_string(),
+    }
+}
+
+fn tone(degree: u8, alteration: i8) -> ChordTone {
+    ChordTone::new_unchecked(degree, alteration)
+}
+
+fn validate_modifier(modifier: &ChordModifier) -> Result<(), ChordError> {
+    match modifier {
+        ChordModifier::Add(tone) => {
+            if !matches!(tone.degree, 2 | 3 | 4 | 6 | 9 | 11 | 13) {
+                return Err(ChordError::InvalidModifier(format_modifier(modifier)));
+            }
+        }
+        ChordModifier::Alter(tone) => {
+            if tone.alteration == 0 || !matches!(tone.degree, 5 | 9 | 11 | 13) {
+                return Err(ChordError::InvalidModifier(format_modifier(modifier)));
+            }
+        }
+        ChordModifier::Omit(degree) => {
+            if !matches!(degree, 3 | 5 | 7 | 9 | 11 | 13) {
+                return Err(ChordError::InvalidModifier(format_modifier(modifier)));
+            }
+        }
+        ChordModifier::Altered => {}
+    }
+    Ok(())
+}
+
+fn modifier_degree(modifier: &ChordModifier) -> Option<u8> {
+    match modifier {
+        ChordModifier::Add(tone) | ChordModifier::Alter(tone) => Some(tone.degree),
+        ChordModifier::Omit(degree) => Some(*degree),
+        ChordModifier::Altered => None,
+    }
+}
+
+fn modifier_sort_key(modifier: &ChordModifier) -> (u8, u8, i8) {
+    match modifier {
+        ChordModifier::Alter(tone) => (0, tone.degree, tone.alteration),
+        ChordModifier::Add(tone) => (1, tone.degree, tone.alteration),
+        ChordModifier::Omit(degree) => (2, *degree, 0),
+        ChordModifier::Altered => (3, 0, 0),
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -39,6 +39,10 @@
 //!
 //! // returns a Vector of the Notes of the chord
 //! let chord_notes = chord.notes();
+//!
+//! // Or parse a complete lead-sheet symbol.
+//! let altered = Chord::parse("C7(b9,#11)").unwrap();
+//! assert_eq!(altered.canonical_symbol(), "C7b9#11");
 //! ```
 //!
 //! ## MIDI Export (optional feature)
@@ -46,7 +50,7 @@
 //! With the `midi` feature enabled, you can export chords and scales to MIDI files:
 //!
 //! ```toml
-//! rust-music-theory = { version = "0.4", features = ["midi"] }
+//! rust-music-theory = { version = "0.5", features = ["midi"] }
 //! ```
 //!
 //! ```ignore
@@ -61,7 +65,7 @@
 //! With the `midi-playback` feature, play to connected MIDI instruments:
 //!
 //! ```toml
-//! rust-music-theory = { version = "0.4", features = ["midi-playback"] }
+//! rust-music-theory = { version = "0.5", features = ["midi-playback"] }
 //! ```
 //!
 //! ```ignore

--- a/src/note/note.rs
+++ b/src/note/note.rs
@@ -22,9 +22,18 @@ impl Note {
     /// Middle C (C4) = 60, A4 (440Hz) = 69.
     /// Uses standard MIDI octave convention where octave -1 starts at 0.
     pub fn midi_pitch(&self) -> u8 {
-        let semitone = self.pitch.into_u8();
-        let midi_value = (self.octave as u16 + 1) * 12 + semitone as u16;
-        midi_value.min(127) as u8
+        use crate::note::NoteLetter::*;
+        let natural = match self.pitch.letter {
+            C => 0,
+            D => 2,
+            E => 4,
+            F => 5,
+            G => 7,
+            A => 9,
+            B => 11,
+        };
+        let midi_value = (self.octave as i32 + 1) * 12 + natural + self.pitch.accidental as i32;
+        midi_value.clamp(0, 127) as u8
     }
 }
 

--- a/src/note/pitch.rs
+++ b/src/note/pitch.rs
@@ -11,7 +11,7 @@ use std::str::FromStr;
 use strum_macros::EnumIter;
 
 lazy_static! {
-    static ref REGEX_PITCH: Regex = Regex::new("^[ABCDEFGabcdefg][b♭#sS♯𝄪x]*").unwrap();
+    static ref REGEX_PITCH: Regex = Regex::new("^[ABCDEFGabcdefg][b♭𝄫#sS♯𝄪x]*").unwrap();
 }
 
 /// A note letter without an accidental.
@@ -260,27 +260,27 @@ impl Pitch {
             _ => return None,
         };
 
-        let mut accidental = 0;
+        let mut accidental: i8 = 0;
         let sharps: HashMap<char, i8> =
             [('#', 1), ('s', 1), ('S', 1), ('♯', 1), ('𝄪', 2), ('x', 2)]
                 .iter()
                 .cloned()
                 .collect();
-        let flats: HashMap<char, i8> = [('b', -1), ('♭', -1)].iter().cloned().collect();
+        let flats: HashMap<char, i8> = [('b', -1), ('♭', -1), ('𝄫', -2)].iter().cloned().collect();
         let mut active_map: Option<&HashMap<char, i8>> = None;
         for ch in characters {
             if let Some(map) = active_map {
                 if !map.contains_key(&ch) {
                     return None;
                 }
-                accidental += map.get(&ch).unwrap();
+                accidental = accidental.checked_add(*map.get(&ch).unwrap())?;
             } else {
                 if sharps.contains_key(&ch) {
                     active_map = Some(&sharps);
-                    accidental += sharps.get(&ch).unwrap();
+                    accidental = accidental.checked_add(*sharps.get(&ch).unwrap())?;
                 } else if flats.contains_key(&ch) {
                     active_map = Some(&flats);
-                    accidental += flats.get(&ch).unwrap();
+                    accidental = accidental.checked_add(*flats.get(&ch).unwrap())?;
                 } else {
                     return None;
                 }
@@ -318,7 +318,10 @@ impl fmt::Display for Pitch {
         write!(
             fmt,
             "{}",
-            letter.to_owned() + &(0..self.accidental.abs()).map(|_| acc).collect::<String>()
+            letter.to_owned()
+                + &(0..self.accidental.unsigned_abs())
+                    .map(|_| acc)
+                    .collect::<String>()
         )
     }
 }

--- a/src/wasm/chords.rs
+++ b/src/wasm/chords.rs
@@ -1,10 +1,21 @@
-use wasm_bindgen::prelude::*;
-use crate::note::{Pitch, Notes};
-use crate::chord::Chord;
+use super::parsers::{parse_chord_number, parse_chord_quality, parse_pitch_symbol};
 use super::types::{WasmChord, WasmNote};
-use super::parsers::{parse_pitch_symbol, parse_chord_quality, parse_chord_number};
+use crate::chord::{Chord, ChordModifier, Suspension};
+use crate::note::{Notes, Pitch};
+use wasm_bindgen::prelude::*;
 
-/// Generate a chord from WASM-compatible parameters
+/// Parse a complete lead-sheet chord symbol.
+///
+/// JavaScript receives an exception containing the structured Rust parse
+/// error instead of an ambiguous `null` value.
+#[wasm_bindgen]
+pub fn parse_chord_symbol(symbol: &str) -> Result<JsValue, JsValue> {
+    let chord = Chord::parse(symbol).map_err(|error| JsValue::from_str(&error.to_string()))?;
+    serde_wasm_bindgen::to_value(&to_wasm_chord(&chord))
+        .map_err(|error| JsValue::from_str(&error.to_string()))
+}
+
+/// Generate a chord from the legacy root/quality/number parameters.
 #[wasm_bindgen]
 pub fn generate_chord(root: &str, quality: &str, number: &str) -> JsValue {
     let pitch_symbol = parse_pitch_symbol(root);
@@ -15,18 +26,55 @@ pub fn generate_chord(root: &str, quality: &str, number: &str) -> JsValue {
         Ok(chord) => chord,
         Err(_) => return JsValue::NULL,
     };
-    let notes: Vec<WasmNote> = chord.notes().into_iter().map(WasmNote::from).collect();
-    let wasm_chord = WasmChord {
-        notes,
-        root: root.to_string(),
-        quality: quality.to_string(),
-        number: number.to_string(),
-    };
-
-    serde_wasm_bindgen::to_value(&wasm_chord).unwrap_or(JsValue::NULL)
+    serde_wasm_bindgen::to_value(&to_wasm_chord(&chord)).unwrap_or(JsValue::NULL)
 }
 
-/// Get list of available chord qualities
+fn to_wasm_chord(chord: &Chord) -> WasmChord {
+    let notes = chord.notes().into_iter().map(WasmNote::from).collect();
+    let mut modifiers = Vec::new();
+    if let Some(suspension) = chord.spec().suspension() {
+        modifiers.push(match suspension {
+            Suspension::Second => "sus2".to_string(),
+            Suspension::Fourth => "sus4".to_string(),
+        });
+    }
+    modifiers.extend(chord.spec().modifiers().iter().map(format_modifier));
+    let formula = chord
+        .formula()
+        .tones()
+        .iter()
+        .map(|tone| format_tone(tone.degree(), tone.alteration()))
+        .collect();
+    WasmChord {
+        notes,
+        root: chord.root().to_string(),
+        quality: chord.quality().to_string(),
+        number: chord.number().to_string(),
+        canonical_symbol: chord.canonical_symbol(),
+        bass: chord.bass().map(|bass| bass.to_string()),
+        modifiers,
+        formula,
+    }
+}
+
+fn format_tone(degree: u8, alteration: i8) -> String {
+    let accidental = if alteration < 0 { 'b' } else { '#' };
+    let prefix: String = (0..alteration.unsigned_abs()).map(|_| accidental).collect();
+    format!("{}{}", prefix, degree)
+}
+
+fn format_modifier(modifier: &ChordModifier) -> String {
+    match modifier {
+        ChordModifier::Add(tone) => {
+            format!("add{}", format_tone(tone.degree(), tone.alteration()))
+        }
+        ChordModifier::Alter(tone) => format_tone(tone.degree(), tone.alteration()),
+        ChordModifier::Omit(degree) => format!("no{}", degree),
+        ChordModifier::Altered => "alt".to_string(),
+    }
+}
+
+/// Get the legacy quality names accepted by [`generate_chord`].
 #[wasm_bindgen]
 pub fn get_available_chord_qualities() -> JsValue {
     let qualities = vec![
@@ -38,116 +86,126 @@ pub fn get_available_chord_qualities() -> JsValue {
         "half_diminished",
         "sus2",
         "sus4",
+        "power",
     ];
     serde_wasm_bindgen::to_value(&qualities).unwrap_or(JsValue::NULL)
 }
 
-/// Get list of available chord numbers
+/// Get the legacy number names accepted by [`generate_chord`].
 #[wasm_bindgen]
 pub fn get_available_chord_numbers() -> JsValue {
-    let numbers = vec!["triad", "seventh", "ninth", "eleventh", "thirteenth"];
+    let numbers = vec![
+        "triad",
+        "fifth",
+        "sixth",
+        "six_nine",
+        "seventh",
+        "major_seventh",
+        "ninth",
+        "eleventh",
+        "thirteenth",
+    ];
     serde_wasm_bindgen::to_value(&numbers).unwrap_or(JsValue::NULL)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::chord::{Quality, Number};
+    use crate::chord::{Number, Quality};
 
     #[wasm_bindgen_test::wasm_bindgen_test]
     fn test_chord_generation_logic() {
-        // Test the core logic without WASM bindings
-        let pitch_symbol = parse_pitch_symbol("C");
-        let chord_quality = parse_chord_quality("major");
-        let chord_number = parse_chord_number("triad");
-
-        let chord = Chord::new(Pitch::from(pitch_symbol), chord_quality, chord_number);
-        let notes = chord.notes();
-
-        assert_eq!(notes.len(), 3); // C major triad
-        assert_eq!(chord.quality, Quality::Major);
-        assert_eq!(chord.number, Number::Triad);
-
-        // Convert to WASM types
-        let wasm_notes: Vec<WasmNote> = notes.into_iter().map(WasmNote::from).collect();
-        assert_eq!(wasm_notes.len(), 3);
-        assert_eq!(wasm_notes[0].pitch, "C");
-    }
-
-    #[wasm_bindgen_test::wasm_bindgen_test]
-    fn test_chord_with_sharps_and_flats() {
-        let f_sharp_chord = Chord::new(
-            Pitch::from(parse_pitch_symbol("F#")),
-            parse_chord_quality("minor"),
-            parse_chord_number("seventh"),
+        let chord = Chord::new(
+            Pitch::from(parse_pitch_symbol("C")),
+            parse_chord_quality("major"),
+            parse_chord_number("triad"),
         );
-
-        let notes = f_sharp_chord.notes();
-        assert_eq!(notes.len(), 4); // F# minor seventh
-
-        let wasm_notes: Vec<WasmNote> = notes.into_iter().map(WasmNote::from).collect();
-        assert_eq!(wasm_notes[0].pitch, "F#");
+        assert_eq!(chord.notes().len(), 3);
+        assert_eq!(chord.quality(), Quality::Major);
+        assert_eq!(chord.number(), Number::Triad);
     }
 
     #[wasm_bindgen_test::wasm_bindgen_test]
-    fn test_available_chord_qualities_count() {
-        let qualities = vec![
-            "major",
-            "minor",
-            "diminished",
-            "augmented",
-            "dominant",
-            "half_diminished",
-            "sus2",
-            "sus4",
-        ];
-        assert_eq!(qualities.len(), 8);
+    fn test_complete_symbol_contains_normalized_metadata() {
+        let chord: WasmChord =
+            serde_wasm_bindgen::from_value(parse_chord_symbol("C7(b9,#11)/G").unwrap()).unwrap();
+        assert_eq!(chord.canonical_symbol, "C7b9#11/G");
+        assert_eq!(chord.bass.as_deref(), Some("G"));
+        assert_eq!(chord.modifiers, vec!["b9", "#11"]);
+        assert_eq!(chord.formula, vec!["1", "3", "5", "b7", "b9", "#11"]);
     }
 
     #[wasm_bindgen_test::wasm_bindgen_test]
-    fn test_available_chord_numbers_count() {
-        let numbers = vec!["triad", "seventh", "ninth", "eleventh", "thirteenth"];
-        assert_eq!(numbers.len(), 5);
+    fn test_complete_symbol_returns_an_error() {
+        assert!(parse_chord_symbol("C7altb9").is_err());
     }
 
     #[wasm_bindgen_test::wasm_bindgen_test]
-    fn test_extended_chords() {
-        let ninth_chord = Chord::new(
-            Pitch::from(parse_pitch_symbol("G")),
-            parse_chord_quality("dominant"),
-            parse_chord_number("ninth"),
-        );
-
-        let notes = ninth_chord.notes();
-        assert_eq!(notes.len(), 5); // G dominant ninth
-
-        let wasm_notes: Vec<WasmNote> = notes.into_iter().map(WasmNote::from).collect();
-        assert_eq!(wasm_notes[0].pitch, "G");
+    fn test_suspension_is_exposed_as_a_modifier() {
+        let chord: WasmChord =
+            serde_wasm_bindgen::from_value(parse_chord_symbol("C7sus4").unwrap()).unwrap();
+        assert_eq!(chord.modifiers, vec!["sus4"]);
     }
 
     #[wasm_bindgen_test::wasm_bindgen_test]
-    fn test_exported_chord_generation_and_lists() {
-        let chord: WasmChord = serde_wasm_bindgen::from_value(generate_chord(
-            "C",
-            "augmented",
-            "seventh",
-        ))
-        .unwrap();
+    fn test_aliases_and_compound_degrees_match_the_rust_api() {
+        let alias: WasmChord =
+            serde_wasm_bindgen::from_value(parse_chord_symbol("C+M7").unwrap()).unwrap();
+        assert_eq!(alias.canonical_symbol, "CaugMaj7");
+        assert_eq!(alias.formula, vec!["1", "3", "#5", "7"]);
+
+        let added: WasmChord =
+            serde_wasm_bindgen::from_value(parse_chord_symbol("Cadd13").unwrap()).unwrap();
+        assert_eq!(added.notes.last().unwrap().pitch, "A");
+        assert_eq!(added.notes.last().unwrap().octave, 5);
+    }
+
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn test_malformed_modifier_separators_return_an_error() {
+        assert!(parse_chord_symbol("C7(b9,,#11)").is_err());
+    }
+
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn test_second_audit_unicode_and_power_chord_regressions() {
+        let chord: WasmChord =
+            serde_wasm_bindgen::from_value(parse_chord_symbol("C𝄫maj7").unwrap()).unwrap();
+        assert_eq!(chord.canonical_symbol, "Cbbmaj7");
         assert_eq!(
-            chord.notes.iter().map(|note| note.pitch.as_str()).collect::<Vec<_>>(),
+            chord
+                .notes
+                .iter()
+                .map(|note| (note.pitch.as_str(), note.octave))
+                .collect::<Vec<_>>(),
+            vec![("Cbb", 4), ("Ebb", 4), ("Gbb", 4), ("Bbb", 4)]
+        );
+        assert!(parse_chord_symbol("C5add9").is_err());
+        assert!(parse_chord_symbol("CmMaj6").is_err());
+    }
+
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn test_legacy_generation_and_lists() {
+        let chord: WasmChord =
+            serde_wasm_bindgen::from_value(generate_chord("C", "augmented", "seventh")).unwrap();
+        assert_eq!(
+            chord
+                .notes
+                .iter()
+                .map(|note| note.pitch.as_str())
+                .collect::<Vec<_>>(),
             vec!["C", "E", "G#", "Bb"]
         );
+        assert_eq!(chord.canonical_symbol, "Caug7");
 
         let qualities: Vec<String> =
             serde_wasm_bindgen::from_value(get_available_chord_qualities()).unwrap();
         let numbers: Vec<String> =
             serde_wasm_bindgen::from_value(get_available_chord_numbers()).unwrap();
-        assert!(qualities.contains(&"half_diminished".to_string()));
-        assert!(numbers.contains(&"thirteenth".to_string()));
+        assert!(qualities.contains(&"power".to_string()));
+        assert!(numbers.contains(&"six_nine".to_string()));
     }
 
     #[wasm_bindgen_test::wasm_bindgen_test]
-    fn test_exported_chord_rejects_unsupported_combinations() {
+    fn test_legacy_generation_rejects_unsupported_combinations() {
         assert!(generate_chord("C", "diminished", "ninth").is_null());
     }
 }

--- a/src/wasm/mod.rs
+++ b/src/wasm/mod.rs
@@ -1,15 +1,17 @@
 //! WASM module for exposing rust-music-theory functionality to JavaScript/WebAssembly
 
-pub mod types;
+pub mod chords;
 pub mod parsers;
 pub mod scales;
-pub mod chords;
+pub mod types;
 pub mod utils;
 
 // Re-export the main WASM functions for easier access
-pub use scales::{generate_scale, get_available_scales, get_available_modes};
-pub use chords::{generate_chord, get_available_chord_qualities, get_available_chord_numbers};
-pub use utils::{init, get_chromatic_pitches};
+pub use chords::{
+    generate_chord, get_available_chord_numbers, get_available_chord_qualities, parse_chord_symbol,
+};
+pub use scales::{generate_scale, get_available_modes, get_available_scales};
+pub use utils::{get_chromatic_pitches, init};
 
 // Re-export types for external use
-pub use types::{WasmNote, WasmScale, WasmChord};
+pub use types::{WasmChord, WasmNote, WasmScale};

--- a/src/wasm/parsers.rs
+++ b/src/wasm/parsers.rs
@@ -1,6 +1,6 @@
+use crate::chord::{Number as ChordNumber, Quality as ChordQuality};
 use crate::note::PitchSymbol;
-use crate::scale::{ScaleType, Mode};
-use crate::chord::{Quality as ChordQuality, Number as ChordNumber};
+use crate::scale::{Mode, ScaleType};
 
 /// Parse a string representation of a pitch into a PitchSymbol
 pub fn parse_pitch_symbol(input: &str) -> PitchSymbol {
@@ -66,6 +66,7 @@ pub fn parse_chord_quality(input: &str) -> ChordQuality {
         "half_diminished" => ChordQuality::HalfDiminished,
         "sus2" | "suspended2" => ChordQuality::Suspended2,
         "sus4" | "suspended4" => ChordQuality::Suspended4,
+        "power" => ChordQuality::Power,
         _ => ChordQuality::Major,
     }
 }
@@ -74,7 +75,11 @@ pub fn parse_chord_quality(input: &str) -> ChordQuality {
 pub fn parse_chord_number(input: &str) -> ChordNumber {
     match input.to_lowercase().as_str() {
         "triad" => ChordNumber::Triad,
+        "fifth" => ChordNumber::Fifth,
+        "sixth" => ChordNumber::Sixth,
+        "six_nine" | "6/9" => ChordNumber::SixNine,
         "seventh" => ChordNumber::Seventh,
+        "major_seventh" | "maj7" => ChordNumber::MajorSeventh,
         "ninth" => ChordNumber::Ninth,
         "eleventh" => ChordNumber::Eleventh,
         "thirteenth" => ChordNumber::Thirteenth,
@@ -105,7 +110,10 @@ mod tests {
     fn test_parse_scale_type() {
         assert_eq!(parse_scale_type("diatonic"), ScaleType::Diatonic);
         assert_eq!(parse_scale_type("DIATONIC"), ScaleType::Diatonic);
-        assert_eq!(parse_scale_type("pentatonic_major"), ScaleType::PentatonicMajor);
+        assert_eq!(
+            parse_scale_type("pentatonic_major"),
+            ScaleType::PentatonicMajor
+        );
         assert_eq!(parse_scale_type("blues"), ScaleType::Blues);
         assert_eq!(parse_scale_type("chromatic"), ScaleType::Chromatic);
         assert_eq!(parse_scale_type("harmonic_minor"), ScaleType::HarmonicMinor);

--- a/src/wasm/types.rs
+++ b/src/wasm/types.rs
@@ -26,6 +26,10 @@ pub struct WasmChord {
     pub root: String,
     pub quality: String,
     pub number: String,
+    pub canonical_symbol: String,
+    pub bass: Option<String>,
+    pub modifiers: Vec<String>,
+    pub formula: Vec<String>,
 }
 
 impl From<Note> for WasmNote {

--- a/tests/chord/test_chord.rs
+++ b/tests/chord/test_chord.rs
@@ -76,31 +76,31 @@ mod chord_tests {
 
     #[test]
     fn test_regex() {
-        let chord = Chord::from_regex("F major");
+        let chord = Chord::parse("F major");
         assert!(chord.is_ok());
         let chord = chord.unwrap();
         assert_notes(&vec![F, A, C], chord.notes());
-        assert_eq!(chord.inversion, 0);
+        assert_eq!(chord.inversion(), 0);
     }
 
     #[test]
     fn test_inversion_regex() {
-        let chord = Chord::from_regex("F/C");
-        let chord_num = Chord::from_regex("F/2");
+        let chord = Chord::parse("F/C");
+        let chord_num = Chord::parse("F/2");
         assert!(chord.is_ok());
         assert!(chord_num.is_ok());
         let chord = chord.unwrap();
         let chord_num = chord_num.unwrap();
         assert_notes(&vec![C, F, A], chord.notes());
         assert_notes(&vec![C, F, A], chord_num.notes());
-        assert_eq!(chord.inversion, 2);
-        assert_eq!(chord_num.inversion, 2);
+        assert_eq!(chord.inversion(), 2);
+        assert_eq!(chord_num.inversion(), 2);
     }
 
     #[test]
     fn test_non_chord_slash_bass() {
-        let chord = Chord::from_regex("C/Fs").unwrap();
-        assert_eq!(chord.bass, Some(Pitch::from(Fs)));
+        let chord = Chord::parse("C/Fs").unwrap();
+        assert_eq!(chord.bass(), Some(Pitch::from(Fs)));
         let notes = chord.notes();
         assert_eq!(notes[0], Note::new(Pitch::from(Fs), 3));
         assert_notes(&[C, E, G], notes[1..].to_vec());
@@ -108,12 +108,12 @@ mod chord_tests {
 
     #[test]
     fn test_major_seventh_modifiers_are_not_lost() {
-        let augmented = Chord::from_regex("C Augmented Major Seventh").unwrap();
-        assert_eq!((augmented.quality, augmented.number), (Augmented, MajorSeventh));
+        let augmented = Chord::parse("C Augmented Major Seventh").unwrap();
+        assert_eq!((augmented.quality(), augmented.number()), (Augmented, MajorSeventh));
         assert_notes(&[C, E, Gs, B], augmented.notes());
 
-        let minor = Chord::from_regex("C Minor Major Seventh").unwrap();
-        assert_eq!((minor.quality, minor.number), (Minor, MajorSeventh));
+        let minor = Chord::parse("C Minor Major Seventh").unwrap();
+        assert_eq!((minor.quality(), minor.number()), (Minor, MajorSeventh));
         assert_notes(&[C, Eb, G, B], minor.notes());
     }
 
@@ -124,22 +124,22 @@ mod chord_tests {
             ("C9", Quality::Dominant, Number::Ninth),
             ("C11", Quality::Dominant, Number::Eleventh),
             ("C13", Quality::Dominant, Number::Thirteenth),
-            ("CM7", Quality::Major, Number::Seventh),
+            ("CM7", Quality::Major, Number::MajorSeventh),
             ("Cmaj7", Quality::Major, Number::MajorSeventh),
             ("Cm7", Quality::Minor, Number::Seventh),
         ];
 
         for (symbol, quality, number) in cases {
-            let chord = Chord::from_regex(symbol).unwrap();
-            assert_eq!(chord.quality, quality, "wrong quality for {symbol}");
-            assert_eq!(chord.number, number, "wrong number for {symbol}");
+            let chord = Chord::parse(symbol).unwrap();
+            assert_eq!(chord.quality(), quality, "wrong quality for {symbol}");
+            assert_eq!(chord.number(), number, "wrong number for {symbol}");
         }
     }
 
     #[test]
     fn test_chord_parser_rejects_trailing_text_and_invalid_inversions() {
         for input in ["C garbage", "C major seventh extra", "C/3", "C/", "C//E"] {
-            assert!(Chord::from_regex(input).is_err(), "{} should be invalid", input);
+            assert!(Chord::parse(input).is_err(), "{} should be invalid", input);
         }
     }
 
@@ -165,7 +165,7 @@ mod chord_tests {
 
         for chord_pair in chord_tuples.iter() {
             let chord = Chord::from_string(chord_pair.1).unwrap();
-            let (root, quality, number) = (chord.root, chord.quality, chord.number);
+            let (root, quality, number) = (chord.root(), chord.quality(), chord.number());
             assert_eq!((root, quality, number), (chord_pair.0));
         }
     }
@@ -181,6 +181,9 @@ mod chord_tests {
     fn test_try_new_rejects_unsupported_chords() {
         assert!(Chord::try_new(Pitch::from(C), Diminished, Ninth).is_err());
         assert!(Chord::try_new(Pitch::from(C), HalfDiminished, Triad).is_err());
+        assert!(Chord::try_new(Pitch::from(C), Dominant, Triad).is_err());
+        assert!(Chord::try_new(Pitch::from(C), Suspended4, Seventh).is_err());
+        assert!(Chord::try_new(Pitch::from(C), Diminished, MajorSeventh).is_err());
         assert!(Chord::try_with_inversion(Pitch::from(C), Major, Triad, 3).is_err());
     }
 
@@ -195,7 +198,7 @@ mod chord_tests {
 
         for invalid_chord in invalid_chords {
             assert!(
-                Chord::from_regex(invalid_chord).is_err(),
+                Chord::parse(invalid_chord).is_err(),
                 "Expected error for: {}",
                 invalid_chord
             );
@@ -229,12 +232,12 @@ mod chord_tests {
         let default_chord = Chord::default();
 
         // Verify default chord properties
-        assert_eq!(default_chord.root, Pitch::new(NoteLetter::C, 0));
-        assert_eq!(default_chord.octave, 4);
-        assert_eq!(default_chord.quality, Quality::Major);
-        assert_eq!(default_chord.number, Number::Triad);
-        assert_eq!(default_chord.inversion, 0);
-        assert_eq!(default_chord.bass, None);
+        assert_eq!(default_chord.root(), Pitch::new(NoteLetter::C, 0));
+        assert_eq!(default_chord.octave(), 4);
+        assert_eq!(default_chord.quality(), Quality::Major);
+        assert_eq!(default_chord.number(), Number::Triad);
+        assert_eq!(default_chord.inversion(), 0);
+        assert_eq!(default_chord.bass(), None);
 
         // Default chord has empty intervals, so we need to create one properly
         let c_major = Chord::new(

--- a/tests/chord/test_lead_sheet.rs
+++ b/tests/chord/test_lead_sheet.rs
@@ -1,0 +1,275 @@
+extern crate rust_music_theory as theory;
+
+use theory::chord::{
+    Chord, ChordError, ChordExtension, ChordModifier, Number, Quality, SeventhQuality, Suspension,
+    TriadQuality,
+};
+use theory::note::{NoteLetter, Notes, Pitch};
+
+fn pitches(symbol: &str) -> Vec<String> {
+    Chord::parse(symbol)
+        .unwrap()
+        .notes()
+        .iter()
+        .map(|note| note.pitch.to_string())
+        .collect()
+}
+
+#[test]
+fn parses_requested_symbols_with_canonical_forms_and_spelling() {
+    let cases: &[(&str, &str, &[&str])] = &[
+        ("C7sus4", "C7sus4", &["C", "F", "G", "Bb"]),
+        ("Cm7b5", "Cm7b5", &["C", "Eb", "Gb", "Bb"]),
+        ("Cø7", "Cm7b5", &["C", "Eb", "Gb", "Bb"]),
+        ("Cadd9", "Cadd9", &["C", "E", "G", "D"]),
+        ("C7no5", "C7no5", &["C", "E", "Bb"]),
+        ("C5", "C5", &["C", "G"]),
+        ("C6", "C6", &["C", "E", "G", "A"]),
+        ("Cm6", "Cm6", &["C", "Eb", "G", "A"]),
+        ("C6/9", "C6/9", &["C", "E", "G", "A", "D"]),
+        ("C7alt", "C7alt", &["C", "E", "Gb", "G#", "Bb", "Db", "D#"]),
+        ("CΔ9", "Cmaj9", &["C", "E", "G", "B", "D"]),
+        ("C7(b9,#11)", "C7b9#11", &["C", "E", "G", "Bb", "Db", "F#"]),
+    ];
+
+    for (input, canonical, expected) in cases {
+        let chord = Chord::parse(input).unwrap_or_else(|error| panic!("{}: {}", input, error));
+        assert_eq!(chord.canonical_symbol(), *canonical, "{}", input);
+        assert_eq!(pitches(input), *expected, "{}", input);
+        let reparsed = Chord::parse(&chord.canonical_symbol()).unwrap();
+        assert_eq!(reparsed.spec(), chord.spec(), "{}", input);
+    }
+}
+
+#[test]
+fn slash_basses_and_numeric_inversions_stay_synchronized() {
+    let chord = Chord::parse("Cmaj9#11/G").unwrap();
+    assert_eq!(chord.canonical_symbol(), "Cmaj9#11/G");
+    assert_eq!(chord.bass().unwrap().to_string(), "G");
+    assert_eq!(pitches("Cmaj9#11/G"), ["G", "B", "D", "F#", "C", "E"]);
+
+    let numeric = Chord::parse("C/1").unwrap();
+    assert_eq!(numeric.canonical_symbol(), "C/E");
+    assert_eq!(numeric.inversion(), 1);
+
+    let six_nine = Chord::parse("C6/9/E").unwrap();
+    assert_eq!(six_nine.canonical_symbol(), "C6/9/E");
+    assert_eq!(six_nine.inversion(), 1);
+
+    let non_member = Chord::parse("C/F#").unwrap();
+    assert_eq!(non_member.inversion(), 0);
+    assert_eq!(non_member.canonical_symbol(), "C/F#");
+    assert_eq!(pitches("C/F#"), ["F#", "C", "E", "G"]);
+}
+
+#[test]
+fn builder_produces_the_same_normalized_specification() {
+    let root = Pitch::new(NoteLetter::C, 0);
+    let built = Chord::builder(root)
+        .extension(ChordExtension::Ninth)
+        .seventh_quality(SeventhQuality::Major)
+        .alter(11, 1)
+        .unwrap()
+        .bass(Pitch::new(NoteLetter::G, 0))
+        .build()
+        .unwrap();
+    assert_eq!(built.canonical_symbol(), "Cmaj9#11/G");
+    assert_eq!(built.spec(), Chord::parse("Cmaj9#11/G").unwrap().spec());
+
+    let suspended = Chord::builder(root)
+        .extension(ChordExtension::Seventh)
+        .seventh_quality(SeventhQuality::Minor)
+        .suspension(Suspension::Fourth)
+        .add(3, 0)
+        .unwrap()
+        .build()
+        .unwrap();
+    assert_eq!(suspended.canonical_symbol(), "C7sus4add3");
+    assert!(suspended.spec().modifiers().contains(&ChordModifier::Add(
+        theory::chord::ChordTone::new(3, 0).unwrap()
+    )));
+}
+
+#[test]
+fn builder_rejects_incompatible_seventh_qualities() {
+    let root = Pitch::new(NoteLetter::C, 0);
+    assert!(Chord::builder(root)
+        .triad_quality(TriadQuality::Diminished)
+        .extension(ChordExtension::Seventh)
+        .seventh_quality(SeventhQuality::Major)
+        .build()
+        .is_err());
+    assert!(Chord::builder(root)
+        .extension(ChordExtension::Seventh)
+        .seventh_quality(SeventhQuality::Diminished)
+        .build()
+        .is_err());
+}
+
+#[test]
+fn rejects_conflicts_and_unsupported_tokens_without_panicking() {
+    for symbol in [
+        "C7b9b9",
+        "C7b9#9",
+        "Csus2sus4",
+        "C7altb9",
+        "Cadd5",
+        "C7no2",
+        "Cdim7b5",
+        "Caug7#5",
+        "C/",
+        "C//E",
+        "C[maj7]",
+        "C7(b9",
+        "C7b9)",
+    ] {
+        let result = std::panic::catch_unwind(|| Chord::parse(symbol));
+        assert!(result.is_ok(), "{} panicked", symbol);
+        assert!(result.unwrap().is_err(), "{} should be rejected", symbol);
+    }
+}
+
+#[test]
+fn theoretical_roots_keep_generic_letter_spelling() {
+    assert_eq!(pitches("C#maj9#11"), ["C#", "E#", "G#", "B#", "D#", "F##"]);
+    assert_eq!(pitches("Cb7b9"), ["Cb", "Eb", "Gb", "Bbb", "Dbb"]);
+}
+
+#[test]
+fn public_spec_types_describe_the_normalized_chord() {
+    let chord = Chord::parse("Cm7b5").unwrap();
+    assert_eq!(chord.spec().triad_quality(), TriadQuality::Diminished);
+    assert_eq!(chord.spec().seventh_quality(), Some(SeventhQuality::Minor));
+    assert_eq!(chord.spec().extension(), ChordExtension::Seventh);
+    assert_eq!(
+        chord
+            .formula()
+            .tones()
+            .iter()
+            .map(|tone| (tone.degree(), tone.alteration()))
+            .collect::<Vec<_>>(),
+        vec![(1, 0), (3, -1), (5, -1), (7, -1)]
+    );
+}
+
+#[test]
+fn legacy_power_and_sixth_adapters_remain_available() {
+    let root = Pitch::new(NoteLetter::C, 0);
+    assert_eq!(
+        Chord::new(root, Quality::Power, Number::Fifth).canonical_symbol(),
+        "C5"
+    );
+    assert_eq!(
+        Chord::new(root, Quality::Major, Number::Sixth).canonical_symbol(),
+        "C6"
+    );
+    assert_eq!(
+        Chord::new(root, Quality::Minor, Number::SixNine).canonical_symbol(),
+        "Cm6/9"
+    );
+    assert_eq!(Chord::from_interval(root, &[7]).unwrap().to_string(), "C5");
+    assert_eq!(
+        Chord::from_interval(root, &[4, 3, 2, 5])
+            .unwrap()
+            .to_string(),
+        "C6/9"
+    );
+}
+
+#[test]
+#[allow(deprecated)]
+fn deprecated_regex_name_delegates_to_the_new_parser() {
+    assert_eq!(
+        Chord::from_regex("Cø7").unwrap().canonical_symbol(),
+        "Cm7b5"
+    );
+}
+
+#[test]
+fn every_core_family_round_trips_across_natural_sharp_and_flat_roots() {
+    let roots = ["C", "F#", "Bb", "Cb", "E#"];
+    let suffixes = [
+        "", "m", "dim", "aug", "5", "6", "m6", "6/9", "m6/9", "7", "maj7", "m7", "mMaj7", "m7b5",
+        "dim7", "aug7", "augMaj7", "9", "maj9", "m9", "mMaj9", "11", "maj11", "m11", "mMaj11",
+        "13", "maj13", "m13", "mMaj13", "sus2", "sus4", "7sus4", "add2", "add4", "add6", "add9",
+        "add11", "add13", "7b5", "7#5", "7b9", "7#9", "7#11", "7b13", "7no5", "7alt",
+    ];
+
+    for root in roots {
+        for suffix in suffixes {
+            let symbol = format!("{}{}", root, suffix);
+            let chord = Chord::parse(&symbol)
+                .unwrap_or_else(|error| panic!("{} should parse: {}", symbol, error));
+            assert_eq!(
+                chord.notes().len(),
+                chord.formula().tones().len(),
+                "{}",
+                symbol
+            );
+            let canonical = chord.canonical_symbol();
+            let reparsed = Chord::parse(&canonical).unwrap();
+            assert_eq!(reparsed.spec(), chord.spec(), "{} -> {}", symbol, canonical);
+            assert_eq!(
+                reparsed.notes(),
+                chord.notes(),
+                "{} -> {}",
+                symbol,
+                canonical
+            );
+        }
+    }
+}
+
+#[test]
+fn aliases_and_modifier_order_normalize_deterministically() {
+    for (alias, canonical) in [
+        ("C^7", "Cmaj7"),
+        ("CM7", "Cmaj7"),
+        ("C-7", "Cm7"),
+        ("C°7", "Cdim7"),
+        ("Co7", "Cdim7"),
+        ("Cø", "Cm7b5"),
+        ("C+7", "Caug7"),
+        ("C7sus", "C7sus4"),
+        ("C7omit5", "C7no5"),
+        ("C♭maj7", "Cbmaj7"),
+        ("F♯m7", "F#m7"),
+    ] {
+        assert_eq!(Chord::parse(alias).unwrap().canonical_symbol(), canonical);
+    }
+
+    assert_eq!(
+        Chord::parse("C7(no5,add13,#11,b9)")
+            .unwrap()
+            .canonical_symbol(),
+        "C7b9#11add13no5"
+    );
+}
+
+#[test]
+fn parse_error_categories_carry_source_positions() {
+    assert!(matches!(
+        Chord::parse("H7"),
+        Err(ChordError::InvalidRoot { position: 0 })
+    ));
+    assert!(matches!(
+        Chord::parse("C7wat"),
+        Err(ChordError::UnexpectedToken { position: 2, .. })
+    ));
+    assert!(matches!(
+        Chord::parse("Cadd5"),
+        Err(ChordError::InvalidModifierAt { position: 1, .. })
+    ));
+    assert!(matches!(
+        Chord::parse("C7b9#9"),
+        Err(ChordError::ConflictingModifiersAt { position: 4, .. })
+    ));
+    assert!(matches!(
+        Chord::parse("C/"),
+        Err(ChordError::InvalidSlashBass { position: 2 })
+    ));
+    assert!(matches!(
+        Chord::parse("C/9"),
+        Err(ChordError::InvalidSlashBass { position: 2 })
+    ));
+}

--- a/tests/chord/test_lead_sheet_audit.rs
+++ b/tests/chord/test_lead_sheet_audit.rs
@@ -1,0 +1,489 @@
+extern crate rust_music_theory as theory;
+
+use std::panic;
+
+use theory::chord::{
+    Chord, ChordError, ChordExtension, ChordSpec, Number, Quality, SeventhQuality, Suspension,
+    TriadQuality,
+};
+use theory::note::{Note, NoteLetter, Notes, Pitch};
+
+fn formula(symbol: &str) -> Vec<(u8, i8)> {
+    Chord::parse(symbol)
+        .unwrap_or_else(|error| panic!("{} should parse: {}", symbol, error))
+        .formula()
+        .tones()
+        .iter()
+        .map(|tone| (tone.degree(), tone.alteration()))
+        .collect()
+}
+
+fn absolute(note: &Note) -> i32 {
+    let natural = match note.pitch.letter {
+        NoteLetter::C => 0,
+        NoteLetter::D => 2,
+        NoteLetter::E => 4,
+        NoteLetter::F => 5,
+        NoteLetter::G => 7,
+        NoteLetter::A => 9,
+        NoteLetter::B => 11,
+    };
+    note.octave as i32 * 12 + natural + note.pitch.accidental as i32
+}
+
+fn letter_index(letter: NoteLetter) -> i16 {
+    match letter {
+        NoteLetter::C => 0,
+        NoteLetter::D => 1,
+        NoteLetter::E => 2,
+        NoteLetter::F => 3,
+        NoteLetter::G => 4,
+        NoteLetter::A => 5,
+        NoteLetter::B => 6,
+    }
+}
+
+// MusicXML 4.0 kind-value defines these base chord formulas. The additional
+// six-nine, minor-major extensions, and deterministic alt formula are explicit
+// requirements of this crate's v0.5 grammar.
+// https://www.w3.org/2021/06/musicxml40/musicxml-reference/data-types/kind-value/
+#[test]
+fn source_backed_core_formula_matrix_is_exact() {
+    let cases: &[(&str, &[(u8, i8)])] = &[
+        ("C", &[(1, 0), (3, 0), (5, 0)]),
+        ("Cm", &[(1, 0), (3, -1), (5, 0)]),
+        ("Cdim", &[(1, 0), (3, -1), (5, -1)]),
+        ("Caug", &[(1, 0), (3, 0), (5, 1)]),
+        ("C5", &[(1, 0), (5, 0)]),
+        ("C6", &[(1, 0), (3, 0), (5, 0), (6, 0)]),
+        ("Cm6", &[(1, 0), (3, -1), (5, 0), (6, 0)]),
+        ("C6/9", &[(1, 0), (3, 0), (5, 0), (6, 0), (9, 0)]),
+        ("Cm6/9", &[(1, 0), (3, -1), (5, 0), (6, 0), (9, 0)]),
+        ("C7", &[(1, 0), (3, 0), (5, 0), (7, -1)]),
+        ("Cmaj7", &[(1, 0), (3, 0), (5, 0), (7, 0)]),
+        ("Cm7", &[(1, 0), (3, -1), (5, 0), (7, -1)]),
+        ("CmMaj7", &[(1, 0), (3, -1), (5, 0), (7, 0)]),
+        ("Cm7b5", &[(1, 0), (3, -1), (5, -1), (7, -1)]),
+        ("Cdim7", &[(1, 0), (3, -1), (5, -1), (7, -2)]),
+        ("Caug7", &[(1, 0), (3, 0), (5, 1), (7, -1)]),
+        ("CaugMaj7", &[(1, 0), (3, 0), (5, 1), (7, 0)]),
+        ("C9", &[(1, 0), (3, 0), (5, 0), (7, -1), (9, 0)]),
+        ("Cmaj9", &[(1, 0), (3, 0), (5, 0), (7, 0), (9, 0)]),
+        ("Cm9", &[(1, 0), (3, -1), (5, 0), (7, -1), (9, 0)]),
+        ("CmMaj9", &[(1, 0), (3, -1), (5, 0), (7, 0), (9, 0)]),
+        ("C11", &[(1, 0), (3, 0), (5, 0), (7, -1), (9, 0), (11, 0)]),
+        ("Cmaj11", &[(1, 0), (3, 0), (5, 0), (7, 0), (9, 0), (11, 0)]),
+        ("Cm11", &[(1, 0), (3, -1), (5, 0), (7, -1), (9, 0), (11, 0)]),
+        (
+            "CmMaj11",
+            &[(1, 0), (3, -1), (5, 0), (7, 0), (9, 0), (11, 0)],
+        ),
+        (
+            "C13",
+            &[(1, 0), (3, 0), (5, 0), (7, -1), (9, 0), (11, 0), (13, 0)],
+        ),
+        (
+            "Cmaj13",
+            &[(1, 0), (3, 0), (5, 0), (7, 0), (9, 0), (11, 0), (13, 0)],
+        ),
+        (
+            "Cm13",
+            &[(1, 0), (3, -1), (5, 0), (7, -1), (9, 0), (11, 0), (13, 0)],
+        ),
+        (
+            "CmMaj13",
+            &[(1, 0), (3, -1), (5, 0), (7, 0), (9, 0), (11, 0), (13, 0)],
+        ),
+        ("Csus2", &[(1, 0), (2, 0), (5, 0)]),
+        ("Csus4", &[(1, 0), (4, 0), (5, 0)]),
+        ("C7sus4", &[(1, 0), (4, 0), (5, 0), (7, -1)]),
+        (
+            "C7alt",
+            &[(1, 0), (3, 0), (5, -1), (5, 1), (7, -1), (9, -1), (9, 1)],
+        ),
+    ];
+
+    for (symbol, expected) in cases {
+        assert_eq!(formula(symbol), *expected, "{}", symbol);
+    }
+}
+
+// These aliases are present in Tonal's current chord dictionary and/or the
+// ChordPro reference implementation's built-in extension list.
+// https://github.com/tonaljs/tonal/blob/main/packages/chord-type/data.ts
+// https://www.chordpro.org/chordpro/chordpro-chords/
+#[test]
+fn common_tonal_and_chordpro_aliases_normalize_portably() {
+    for (input, canonical) in [
+        ("Cma7", "Cmaj7"),
+        ("CMaj7", "Cmaj7"),
+        ("CMadd9", "Cadd9"),
+        ("Cmi7", "Cm7"),
+        ("Cmin7", "Cm7"),
+        ("Cmadd9", "Cmadd9"),
+        ("C69", "C6/9"),
+        ("C6add9", "C6/9"),
+        ("CM69", "C6/9"),
+        ("Cm69", "Cm6/9"),
+        ("Cm6add9", "Cm6/9"),
+        ("C-69", "Cm6/9"),
+        ("Ch", "Cm7b5"),
+        ("Ch7", "Cm7b5"),
+        ("C0", "Cdim"),
+        ("C07", "Cdim7"),
+        ("Calt", "C7alt"),
+        ("Calt7", "C7alt"),
+        ("C7+", "Caug7"),
+        ("C7aug", "Caug7"),
+        ("C+M7", "CaugMaj7"),
+        ("CaugM7", "CaugMaj7"),
+        ("CmM7", "CmMaj7"),
+        ("Cm/M7", "CmMaj7"),
+        ("Cm/ma7", "CmMaj7"),
+        ("C-Δ7", "CmMaj7"),
+        ("C2", "Cadd2"),
+        ("C4", "Cadd4"),
+        ("C69/E", "C6/9/E"),
+        ("Cm7sus4", "Cm7sus4"),
+    ] {
+        let chord = Chord::parse(input).unwrap_or_else(|error| panic!("{}: {}", input, error));
+        assert_eq!(chord.canonical_symbol(), canonical, "{}", input);
+        assert_eq!(
+            Chord::parse(canonical).unwrap().spec(),
+            chord.spec(),
+            "{}",
+            input
+        );
+    }
+    assert_eq!(formula("Cm7sus4"), [(1, 0), (4, 0), (5, 0), (7, -1)]);
+}
+
+#[test]
+fn degree_operations_resolve_in_base_suspend_alter_add_omit_order() {
+    assert_eq!(
+        formula("C7sus4add3#11no5"),
+        [(1, 0), (3, 0), (4, 0), (7, -1), (11, 1)]
+    );
+    assert_eq!(
+        Chord::parse("C7sus4add3#11no5").unwrap().canonical_symbol(),
+        "C7sus4#11add3no5"
+    );
+    assert_eq!(
+        formula("Cm7sus4addb3"),
+        [(1, 0), (3, -1), (4, 0), (5, 0), (7, -1)]
+    );
+    assert_eq!(
+        formula("C9b9add11no5"),
+        [(1, 0), (3, 0), (7, -1), (9, -1), (11, 0)]
+    );
+}
+
+#[test]
+fn simple_and_compound_additions_keep_distinct_octave_intent() {
+    let cases = [
+        ("Cadd2", vec![("C", 4), ("D", 4), ("E", 4), ("G", 4)]),
+        ("Cadd9", vec![("C", 4), ("E", 4), ("G", 4), ("D", 5)]),
+        ("Cadd6", vec![("C", 4), ("E", 4), ("G", 4), ("A", 4)]),
+        ("Cadd13", vec![("C", 4), ("E", 4), ("G", 4), ("A", 5)]),
+        (
+            "C6/9",
+            vec![("C", 4), ("E", 4), ("G", 4), ("A", 4), ("D", 5)],
+        ),
+    ];
+
+    for (symbol, expected) in cases {
+        let actual: Vec<(String, i16)> = Chord::parse(symbol)
+            .unwrap()
+            .notes()
+            .iter()
+            .map(|note| (note.pitch.to_string(), note.octave))
+            .collect();
+        let expected: Vec<(String, i16)> = expected
+            .into_iter()
+            .map(|(pitch, octave)| (pitch.to_string(), octave))
+            .collect();
+        assert_eq!(actual, expected, "{}", symbol);
+    }
+}
+
+fn permutations(items: &[&str]) -> Vec<Vec<String>> {
+    fn visit(items: &mut Vec<String>, index: usize, output: &mut Vec<Vec<String>>) {
+        if index == items.len() {
+            output.push(items.clone());
+            return;
+        }
+        for next in index..items.len() {
+            items.swap(index, next);
+            visit(items, index + 1, output);
+            items.swap(index, next);
+        }
+    }
+
+    let mut items: Vec<String> = items.iter().map(|item| item.to_string()).collect();
+    let mut output = Vec::new();
+    visit(&mut items, 0, &mut output);
+    output
+}
+
+#[test]
+fn every_modifier_permutation_has_one_canonical_form() {
+    let expected = Chord::parse("C7b9#11add13no5").unwrap();
+    for permutation in permutations(&["b9", "#11", "add13", "no5"]) {
+        let symbol = format!("C7{}", permutation.join(""));
+        let chord = Chord::parse(&symbol).unwrap_or_else(|error| panic!("{}: {}", symbol, error));
+        assert_eq!(chord.canonical_symbol(), "C7b9#11add13no5", "{}", symbol);
+        assert_eq!(chord.spec(), expected.spec(), "{}", symbol);
+        assert_eq!(chord.notes(), expected.notes(), "{}", symbol);
+    }
+}
+
+#[test]
+fn altered_major_triads_have_unambiguous_canonical_round_trips() {
+    for (input, canonical) in [
+        ("C(b5)", "Cmajb5"),
+        ("C(#5)", "Cmaj#5"),
+        ("C(#11)", "Cmaj#11"),
+        ("C#(b5)", "C#majb5"),
+        ("Cb(#11)", "Cbmaj#11"),
+    ] {
+        let chord = Chord::parse(input).unwrap();
+        assert_eq!(chord.canonical_symbol(), canonical, "{}", input);
+        let reparsed = Chord::parse(canonical).unwrap();
+        assert_eq!(reparsed.spec(), chord.spec(), "{}", input);
+        assert_eq!(reparsed.notes(), chord.notes(), "{}", input);
+    }
+
+    assert_eq!(Chord::parse("Cb5").unwrap().canonical_symbol(), "Cb5");
+    assert_eq!(Chord::parse("C#11").unwrap().canonical_symbol(), "C#11");
+}
+
+#[test]
+fn generated_notes_match_every_formula_tone_for_theoretical_roots() {
+    let suffixes = [
+        "", "m", "dim", "aug", "5", "6/9", "m6/9", "7", "maj7", "mMaj7", "m7b5", "dim7", "augMaj7",
+        "13", "maj13", "m13", "mMaj13", "7sus4", "add2", "add9", "add13", "7b9#11", "7no5", "7alt",
+    ];
+    let letters = [
+        NoteLetter::C,
+        NoteLetter::D,
+        NoteLetter::E,
+        NoteLetter::F,
+        NoteLetter::G,
+        NoteLetter::A,
+        NoteLetter::B,
+    ];
+
+    for root_letter in letters {
+        for root_alteration in -2..=2 {
+            let root = Pitch::new(root_letter, root_alteration);
+            for suffix in suffixes {
+                let symbol = format!("{}{}", root, suffix);
+                let chord = Chord::parse(&symbol).unwrap();
+                let notes = chord.notes();
+                assert_eq!(notes.len(), chord.formula().tones().len(), "{}", symbol);
+                let root_absolute = absolute(&Note::new(root, 4));
+                for (note, tone) in notes.iter().zip(chord.formula().tones()) {
+                    assert_eq!(
+                        absolute(note) - root_absolute,
+                        tone.semitones() as i32,
+                        "{} degree {}",
+                        symbol,
+                        tone.degree()
+                    );
+                    assert_eq!(
+                        (letter_index(note.pitch.letter) - letter_index(root_letter)).rem_euclid(7),
+                        (tone.degree() as i16 - 1).rem_euclid(7),
+                        "{} degree {} spelling",
+                        symbol,
+                        tone.degree()
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn every_numeric_inversion_is_ordered_and_formats_its_actual_bass() {
+    for base in ["C", "Cm7", "Cdim7", "C6/9", "Cmaj9#11", "C13", "C7alt"] {
+        let root_position = Chord::parse(base).unwrap();
+        for inversion in 0..root_position.formula().tones().len() {
+            let symbol = format!("{}/{}", base, inversion);
+            let chord = Chord::parse(&symbol).unwrap();
+            let notes = chord.notes();
+            assert_eq!(chord.inversion(), inversion as u8, "{}", symbol);
+            assert!(
+                notes
+                    .windows(2)
+                    .all(|window| absolute(&window[0]) < absolute(&window[1])),
+                "{} is not strictly ascending: {:?}",
+                symbol,
+                notes
+            );
+            if inversion == 0 {
+                assert_eq!(chord.canonical_symbol(), base, "{}", symbol);
+            } else {
+                assert_eq!(chord.bass(), Some(notes[0].pitch), "{}", symbol);
+                assert!(
+                    chord
+                        .canonical_symbol()
+                        .ends_with(&format!("/{}", notes[0].pitch)),
+                    "{}",
+                    symbol
+                );
+            }
+        }
+        let invalid = format!("{}/{}", base, root_position.formula().tones().len());
+        assert!(matches!(
+            Chord::parse(&invalid),
+            Err(ChordError::InvalidSlashBass { .. })
+        ));
+    }
+}
+
+#[test]
+fn chord_member_and_non_chord_slash_basses_have_distinct_behavior() {
+    let member = Chord::parse("Cmaj7/D##").unwrap();
+    assert_eq!(member.inversion(), 1);
+    assert_eq!(member.canonical_symbol(), "Cmaj7/E");
+    assert_eq!(member.notes()[0].pitch.to_string(), "E");
+
+    for bass in ["Db", "D", "F", "Gb", "Ab", "A", "Bb"] {
+        let symbol = format!("Cmaj7/{}", bass);
+        let chord = Chord::parse(&symbol).unwrap();
+        let notes = chord.notes();
+        assert_eq!(chord.inversion(), 0, "{}", symbol);
+        assert_eq!(chord.bass().unwrap().to_string(), bass, "{}", symbol);
+        assert_eq!(notes[0].pitch.to_string(), bass, "{}", symbol);
+        assert!(absolute(&notes[0]) < absolute(&notes[1]), "{}", symbol);
+    }
+}
+
+#[test]
+fn malformed_and_unicode_input_never_panics() {
+    let mut invalid = vec![
+        "".to_string(),
+        " ".to_string(),
+        "🎵".to_string(),
+        "N.C.".to_string(),
+        "[C7]".to_string(),
+        "C7()".to_string(),
+        "C7(,)".to_string(),
+        "C7((b9))".to_string(),
+        "C7(b9,,#11)".to_string(),
+        "C7(b9,#11".to_string(),
+        "C7b9,#11)".to_string(),
+        "C///E".to_string(),
+        "C6/9/".to_string(),
+        "C/999999999999999999999999".to_string(),
+        "C/H".to_string(),
+        "C7add8".to_string(),
+        "C7omit8".to_string(),
+        "C7b8".to_string(),
+        "C7###9".to_string(),
+        "C7bbb9".to_string(),
+        "C7altadd9".to_string(),
+        "C7sus2sus4".to_string(),
+        "Cno3no5".to_string(),
+        "C7no3no5no7".to_string(),
+        "C♯♭7".to_string(),
+        "C𝄪♭7".to_string(),
+        "C\0maj7".to_string(),
+    ];
+    invalid.push(format!("C{}7", "#".repeat(512)));
+    invalid.push(format!("C7{}9", "#".repeat(512)));
+    invalid.push(format!("C/E{}", "b".repeat(512)));
+
+    for symbol in invalid {
+        let result = panic::catch_unwind(|| Chord::parse(&symbol));
+        assert!(result.is_ok(), "{} panicked", symbol.escape_debug());
+        assert!(
+            result.unwrap().is_err(),
+            "{} should be rejected",
+            symbol.escape_debug()
+        );
+    }
+}
+
+#[test]
+fn builder_and_spec_validation_reject_every_incompatible_construction() {
+    let root = Pitch::new(NoteLetter::C, 0);
+    assert!(ChordSpec::new(TriadQuality::Major, None, ChordExtension::Seventh).is_err());
+    assert!(ChordSpec::new(
+        TriadQuality::Major,
+        Some(SeventhQuality::Minor),
+        ChordExtension::Triad
+    )
+    .is_err());
+    assert!(ChordSpec::new(TriadQuality::Power, None, ChordExtension::Sixth).is_err());
+    assert!(ChordSpec::new(
+        TriadQuality::Diminished,
+        Some(SeventhQuality::Diminished),
+        ChordExtension::Ninth
+    )
+    .is_err());
+    assert!(Chord::builder(root)
+        .triad_quality(TriadQuality::Augmented)
+        .suspension(Suspension::Fourth)
+        .build()
+        .is_err());
+    assert!(Chord::builder(root)
+        .extension(ChordExtension::Seventh)
+        .seventh_quality(SeventhQuality::Minor)
+        .altered()
+        .add(9, -1)
+        .unwrap()
+        .build()
+        .is_err());
+    assert!(Chord::builder(root)
+        .add(9, 0)
+        .unwrap()
+        .add(9, 0)
+        .unwrap()
+        .build()
+        .is_err());
+    assert!(Chord::builder(root).omit(3).omit(5).build().is_err());
+}
+
+#[test]
+fn every_legacy_quality_number_pair_is_fallible_without_panicking() {
+    let qualities = [
+        Quality::Major,
+        Quality::Minor,
+        Quality::Diminished,
+        Quality::Augmented,
+        Quality::HalfDiminished,
+        Quality::Dominant,
+        Quality::Suspended2,
+        Quality::Suspended4,
+        Quality::Power,
+    ];
+    let numbers = [
+        Number::Triad,
+        Number::Fifth,
+        Number::Sixth,
+        Number::SixNine,
+        Number::Seventh,
+        Number::MajorSeventh,
+        Number::Ninth,
+        Number::Eleventh,
+        Number::Thirteenth,
+    ];
+    let root = Pitch::new(NoteLetter::F, 1);
+
+    for quality in qualities {
+        for number in numbers {
+            let result = panic::catch_unwind(|| Chord::try_new(root, quality, number));
+            assert!(result.is_ok(), "{:?} {:?} panicked", quality, number);
+            if let Ok(chord) = result.unwrap() {
+                assert_eq!(chord.root(), root);
+                assert_eq!(chord.quality(), quality);
+                assert_eq!(chord.number(), number);
+                assert_eq!(chord.intervals().len() + 1, chord.formula().tones().len());
+                let reparsed = Chord::parse(&chord.canonical_symbol()).unwrap();
+                assert_eq!(reparsed.spec(), chord.spec());
+                assert_eq!(reparsed.notes(), chord.notes());
+            }
+        }
+    }
+}

--- a/tests/chord/test_lead_sheet_second_audit.rs
+++ b/tests/chord/test_lead_sheet_second_audit.rs
@@ -1,0 +1,372 @@
+extern crate rust_music_theory as theory;
+
+use std::panic;
+
+use theory::chord::{
+    Chord, ChordBuilder, ChordError, ChordExtension, ChordTone, SeventhQuality, Suspension,
+    TriadQuality,
+};
+use theory::note::{Note, NoteLetter, Notes, Pitch};
+
+fn configure_builder(
+    root: Pitch,
+    triad: TriadQuality,
+    seventh: Option<SeventhQuality>,
+    extension: ChordExtension,
+    suspension: Option<Suspension>,
+) -> ChordBuilder {
+    let mut builder = Chord::builder(root)
+        .triad_quality(triad)
+        .extension(extension);
+    if let Some(seventh) = seventh {
+        builder = builder.seventh_quality(seventh);
+    }
+    if let Some(suspension) = suspension {
+        builder = builder.suspension(suspension);
+    }
+    builder
+}
+
+fn scientific_semitones(note: &Note) -> i32 {
+    let natural = match note.pitch.letter {
+        NoteLetter::C => 0,
+        NoteLetter::D => 2,
+        NoteLetter::E => 4,
+        NoteLetter::F => 5,
+        NoteLetter::G => 7,
+        NoteLetter::A => 9,
+        NoteLetter::B => 11,
+    };
+    (note.octave as i32 + 1) * 12 + natural + note.pitch.accidental as i32
+}
+
+fn assert_round_trip(chord: Chord) {
+    let canonical = chord.canonical_symbol();
+    let reparsed = Chord::parse(&canonical)
+        .unwrap_or_else(|error| panic!("{} should reparse: {}", canonical, error));
+    assert_eq!(reparsed.spec(), chord.spec(), "{}", canonical);
+    assert_eq!(reparsed.formula(), chord.formula(), "{}", canonical);
+    assert_eq!(reparsed.notes(), chord.notes(), "{}", canonical);
+}
+
+#[test]
+fn power_chord_marker_is_never_silently_discarded() {
+    assert_eq!(Chord::parse("C5").unwrap().canonical_symbol(), "C5");
+    assert_eq!(Chord::parse("C5/E").unwrap().canonical_symbol(), "C5/E");
+
+    for invalid in ["C5add9", "C5no3", "C5sus2", "C5sus4", "C5b9", "C5#11"] {
+        assert!(
+            Chord::parse(invalid).is_err(),
+            "{} should be rejected",
+            invalid
+        );
+    }
+}
+
+#[test]
+fn quality_markers_are_not_accepted_when_their_meaning_would_be_lost() {
+    for invalid in [
+        "CmMaj", "CmMaj5", "CmMaj6", "CmMaj6/9", "CaugMaj", "Cdom5", "Cdom6", "Cdom6/9",
+    ] {
+        assert!(
+            Chord::parse(invalid).is_err(),
+            "{} should be rejected",
+            invalid
+        );
+    }
+
+    for valid in ["Cmaj", "Cmaj6", "CmMaj7", "CmMaj9", "CaugMaj7", "Cdom"] {
+        assert_round_trip(Chord::parse(valid).unwrap());
+    }
+}
+
+#[test]
+fn unicode_double_accidentals_parse_and_canonicalize_to_ascii() {
+    let double_flat = Pitch::from_str("C𝄫").expect("Unicode double-flat should parse");
+    assert_eq!(double_flat, Pitch::new(NoteLetter::C, -2));
+    assert_eq!(double_flat.to_string(), "Cbb");
+
+    for (input, canonical, pitches) in [
+        ("C𝄫maj7", "Cbbmaj7", vec!["Cbb", "Ebb", "Gbb", "Bbb"]),
+        ("C𝄪maj7", "C##maj7", vec!["C##", "E##", "G##", "B##"]),
+    ] {
+        let chord = Chord::parse(input).unwrap();
+        assert_eq!(chord.canonical_symbol(), canonical);
+        assert_eq!(
+            chord
+                .notes()
+                .iter()
+                .map(|note| note.pitch.to_string())
+                .collect::<Vec<_>>(),
+            pitches
+        );
+        assert_round_trip(chord);
+    }
+}
+
+#[test]
+fn delta_aliases_keep_their_major_seventh_meaning() {
+    for (input, canonical) in [
+        ("CΔ", "Cmaj7"),
+        ("C∆", "Cmaj7"),
+        ("CmΔ", "CmMaj7"),
+        ("CΔ#11", "Cmaj7#11"),
+        ("CΔ/E", "Cmaj7/E"),
+        ("CΔ9", "Cmaj9"),
+        ("CΔ13", "Cmaj13"),
+    ] {
+        let chord = Chord::parse(input).unwrap();
+        assert_eq!(chord.canonical_symbol(), canonical, "{}", input);
+        assert_round_trip(chord);
+    }
+}
+
+#[test]
+fn theoretical_roots_preserve_scientific_octaves_and_midi_intervals() {
+    let roots = [
+        Pitch::new(NoteLetter::C, -2),
+        Pitch::new(NoteLetter::C, -1),
+        Pitch::new(NoteLetter::B, 1),
+        Pitch::new(NoteLetter::B, 2),
+        Pitch::new(NoteLetter::E, 1),
+        Pitch::new(NoteLetter::F, -1),
+    ];
+    let suffixes = [
+        "", "m", "dim7", "6/9", "maj7", "mMaj9", "13", "maj9#11", "add2", "add9", "add13", "7alt",
+    ];
+
+    for root in roots {
+        for suffix in suffixes {
+            let symbol = format!("{}{}", root, suffix);
+            let chord = Chord::parse(&symbol).unwrap();
+            let root_note = Note::new(root, 4);
+            let root_absolute = scientific_semitones(&root_note);
+            for (note, tone) in chord.notes().iter().zip(chord.formula().tones()) {
+                let expected = root_absolute + tone.semitones() as i32;
+                assert_eq!(scientific_semitones(note), expected, "{}", symbol);
+                assert_eq!(
+                    note.midi_pitch() as i32,
+                    expected.clamp(0, 127),
+                    "{}",
+                    symbol
+                );
+            }
+        }
+    }
+}
+
+#[test]
+fn theoretical_inversions_and_slash_basses_are_strictly_ascending_in_midi() {
+    for base in ["Cbmaj9", "B#maj9", "Cbb13", "B##7alt"] {
+        let root_position = Chord::parse(base).unwrap();
+        for inversion in 0..root_position.formula().tones().len() {
+            let chord = Chord::parse(&format!("{}/{}", base, inversion)).unwrap();
+            assert!(
+                chord
+                    .notes()
+                    .windows(2)
+                    .all(|window| scientific_semitones(&window[0])
+                        < scientific_semitones(&window[1])),
+                "{} inversion {}: {:?}",
+                base,
+                inversion,
+                chord.notes()
+            );
+        }
+    }
+
+    for symbol in ["Cbmaj7/D", "B#maj7/F#", "Cbb7/E", "B##m7/A"] {
+        let chord = Chord::parse(symbol).unwrap();
+        let notes = chord.notes();
+        assert!(
+            scientific_semitones(&notes[0]) < scientific_semitones(&notes[1]),
+            "{}",
+            symbol
+        );
+    }
+}
+
+#[test]
+fn every_valid_builder_base_and_single_modifier_has_a_parseable_canonical_form() {
+    let root = Pitch::new(NoteLetter::C, -1);
+    let triads = [
+        TriadQuality::Major,
+        TriadQuality::Minor,
+        TriadQuality::Diminished,
+        TriadQuality::Augmented,
+        TriadQuality::Power,
+    ];
+    let sevenths = [
+        None,
+        Some(SeventhQuality::Major),
+        Some(SeventhQuality::Minor),
+        Some(SeventhQuality::Diminished),
+    ];
+    let extensions = [
+        ChordExtension::Triad,
+        ChordExtension::Sixth,
+        ChordExtension::SixNine,
+        ChordExtension::Seventh,
+        ChordExtension::Ninth,
+        ChordExtension::Eleventh,
+        ChordExtension::Thirteenth,
+    ];
+    let suspensions = [None, Some(Suspension::Second), Some(Suspension::Fourth)];
+
+    for triad in triads {
+        for seventh in sevenths {
+            for extension in extensions {
+                for suspension in suspensions {
+                    let base = configure_builder(root, triad, seventh, extension, suspension);
+                    if let Ok(chord) = base.clone().build() {
+                        assert_round_trip(chord);
+                    }
+
+                    for degree in [2, 3, 4, 6, 9, 11, 13] {
+                        for alteration in -2..=2 {
+                            if let Ok(chord) = base.clone().add(degree, alteration).unwrap().build()
+                            {
+                                assert_round_trip(chord);
+                            }
+                        }
+                    }
+                    for degree in [5, 9, 11, 13] {
+                        for alteration in [-2, -1, 1, 2] {
+                            if let Ok(chord) =
+                                base.clone().alter(degree, alteration).unwrap().build()
+                            {
+                                assert_round_trip(chord);
+                            }
+                        }
+                    }
+                    for degree in [3, 5, 7, 9, 11, 13] {
+                        if let Ok(chord) = base.clone().omit(degree).build() {
+                            assert_round_trip(chord);
+                        }
+                    }
+                    if let Ok(chord) = base.clone().altered().build() {
+                        assert_round_trip(chord);
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn chord_tone_degree_math_and_validation_are_exhaustive() {
+    for (degree, natural) in [
+        (1, 0),
+        (2, 2),
+        (3, 4),
+        (4, 5),
+        (5, 7),
+        (6, 9),
+        (7, 11),
+        (9, 14),
+        (11, 17),
+        (13, 21),
+    ] {
+        for alteration in -2..=2 {
+            let tone = ChordTone::new(degree, alteration).unwrap();
+            assert_eq!(tone.semitones(), natural + alteration as i16);
+            assert_eq!(tone.letter_offset(), (degree as i16 - 1).rem_euclid(7));
+        }
+    }
+
+    for invalid_degree in [0, 8, 10, 12, 14, u8::MAX] {
+        assert!(ChordTone::new(invalid_degree, 0).is_err());
+    }
+    for invalid_alteration in [i8::MIN, -3, 3, i8::MAX] {
+        assert!(ChordTone::new(5, invalid_alteration).is_err());
+    }
+}
+
+#[test]
+fn midi_conversion_clamps_both_ends_without_panicking() {
+    let cases = [
+        (Note::new(Pitch::new(NoteLetter::C, 0), i16::MIN), 0),
+        (Note::new(Pitch::new(NoteLetter::C, -1), -1), 0),
+        (Note::new(Pitch::new(NoteLetter::B, 1), 4), 72),
+        (Note::new(Pitch::new(NoteLetter::C, -1), 4), 59),
+        (Note::new(Pitch::new(NoteLetter::B, 0), i16::MAX), 127),
+    ];
+
+    for (note, expected) in cases {
+        let result = panic::catch_unwind(|| note.midi_pitch());
+        assert!(result.is_ok(), "{:?} panicked", note);
+        assert_eq!(result.unwrap(), expected, "{:?}", note);
+    }
+}
+
+#[test]
+fn generated_token_streams_never_panic_the_parser() {
+    let fragments = [
+        "C", "b", "#", "𝄫", "𝄪", "7", "maj", "sus", "add", "no", "/", "(", ")", ",", "🎵",
+    ];
+    for first in fragments {
+        for second in fragments {
+            for third in fragments {
+                for fourth in fragments {
+                    let symbol = format!("{}{}{}{}", first, second, third, fourth);
+                    assert!(
+                        panic::catch_unwind(|| Chord::parse(&symbol)).is_ok(),
+                        "{}",
+                        symbol
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn parse_errors_point_to_original_bytes_after_alias_and_unicode_normalization() {
+    let cases = [
+        ("CM7/", 4),
+        ("Cøwat", 3),
+        ("C Δ9 wat", 6),
+        ("C7(♭9,wat)", 8),
+        ("C major seventh wat", 16),
+    ];
+
+    for (symbol, expected) in cases {
+        let error = Chord::parse(symbol).unwrap_err();
+        let position = match &error {
+            ChordError::UnexpectedToken { position, .. }
+            | ChordError::InvalidModifierAt { position, .. }
+            | ChordError::ConflictingModifiersAt { position, .. }
+            | ChordError::InvalidSlashBass { position }
+            | ChordError::UnsupportedConstruction { position, .. } => *position,
+            other => panic!("{} returned the wrong error: {:?}", symbol, other),
+        };
+        assert_eq!(position, expected, "{}: {:?}", symbol, error);
+        assert!(
+            symbol.is_char_boundary(position),
+            "{}: {}",
+            symbol,
+            position
+        );
+    }
+}
+
+#[test]
+fn modifier_errors_point_to_the_invalid_or_conflicting_operation() {
+    let cases = [
+        ("C7add5", 2),
+        ("C7b9#9", 4),
+        ("C7altb9", 5),
+        ("Cdim7b5", 5),
+        ("C7(no5,add5)", 7),
+    ];
+
+    for (symbol, expected) in cases {
+        let error = Chord::parse(symbol).unwrap_err();
+        let position = match &error {
+            ChordError::InvalidModifierAt { position, .. }
+            | ChordError::ConflictingModifiersAt { position, .. } => *position,
+            other => panic!("{} returned the wrong error: {:?}", symbol, other),
+        };
+        assert_eq!(position, expected, "{}: {:?}", symbol, error);
+    }
+}

--- a/tests/chord/test_lead_sheet_third_audit.rs
+++ b/tests/chord/test_lead_sheet_third_audit.rs
@@ -1,0 +1,280 @@
+extern crate rust_music_theory as theory;
+
+use std::collections::HashMap;
+use std::panic;
+use std::time::{Duration, Instant};
+
+use theory::chord::{
+    Chord, ChordBuilder, ChordError, ChordExtension, ChordSpec, SeventhQuality, Suspension,
+    TriadQuality,
+};
+use theory::note::{Note, NoteLetter, Notes, Pitch};
+
+fn configure_builder(
+    root: Pitch,
+    triad: TriadQuality,
+    seventh: Option<SeventhQuality>,
+    extension: ChordExtension,
+    suspension: Option<Suspension>,
+) -> ChordBuilder {
+    let mut builder = Chord::builder(root)
+        .triad_quality(triad)
+        .extension(extension);
+    if let Some(seventh) = seventh {
+        builder = builder.seventh_quality(seventh);
+    }
+    if let Some(suspension) = suspension {
+        builder = builder.suspension(suspension);
+    }
+    builder
+}
+
+fn scientific_semitones(note: &Note) -> i32 {
+    let natural = match note.pitch.letter {
+        NoteLetter::C => 0,
+        NoteLetter::D => 2,
+        NoteLetter::E => 4,
+        NoteLetter::F => 5,
+        NoteLetter::G => 7,
+        NoteLetter::A => 9,
+        NoteLetter::B => 11,
+    };
+    note.octave as i32 * 12 + natural + note.pitch.accidental as i32
+}
+
+#[derive(Clone, Copy)]
+enum Operation {
+    Add(u8, i8),
+    Alter(u8, i8),
+    Omit(u8),
+    Altered,
+}
+
+fn apply(builder: ChordBuilder, operation: Operation) -> Result<ChordBuilder, ChordError> {
+    match operation {
+        Operation::Add(degree, alteration) => builder.add(degree, alteration),
+        Operation::Alter(degree, alteration) => builder.alter(degree, alteration),
+        Operation::Omit(degree) => Ok(builder.omit(degree)),
+        Operation::Altered => Ok(builder.altered()),
+    }
+}
+
+fn register_canonical(symbols: &mut HashMap<String, ChordSpec>, chord: Chord) {
+    let canonical = chord.canonical_symbol();
+    if let Some(previous) = symbols.insert(canonical.clone(), chord.spec().clone()) {
+        assert_eq!(
+            previous,
+            *chord.spec(),
+            "canonical collision: {}",
+            canonical
+        );
+    }
+    let reparsed = Chord::parse(&canonical).unwrap();
+    assert_eq!(reparsed.spec(), chord.spec(), "{}", canonical);
+    assert_eq!(reparsed.formula(), chord.formula(), "{}", canonical);
+    assert_eq!(reparsed.notes(), chord.notes(), "{}", canonical);
+}
+
+#[test]
+fn every_valid_two_modifier_builder_has_a_unique_round_trippable_symbol() {
+    let root = Pitch::new(NoteLetter::C, -1);
+    let operations = [
+        Operation::Add(2, 0),
+        Operation::Add(3, 0),
+        Operation::Add(9, -1),
+        Operation::Add(13, 1),
+        Operation::Alter(5, -1),
+        Operation::Alter(5, 1),
+        Operation::Alter(9, -1),
+        Operation::Alter(11, 1),
+        Operation::Alter(13, -1),
+        Operation::Omit(3),
+        Operation::Omit(5),
+        Operation::Omit(7),
+        Operation::Omit(9),
+        Operation::Omit(11),
+        Operation::Altered,
+    ];
+    let mut symbols = HashMap::new();
+
+    for triad in [
+        TriadQuality::Major,
+        TriadQuality::Minor,
+        TriadQuality::Diminished,
+        TriadQuality::Augmented,
+        TriadQuality::Power,
+    ] {
+        for seventh in [
+            None,
+            Some(SeventhQuality::Major),
+            Some(SeventhQuality::Minor),
+            Some(SeventhQuality::Diminished),
+        ] {
+            for extension in [
+                ChordExtension::Triad,
+                ChordExtension::Sixth,
+                ChordExtension::SixNine,
+                ChordExtension::Seventh,
+                ChordExtension::Ninth,
+                ChordExtension::Eleventh,
+                ChordExtension::Thirteenth,
+            ] {
+                for suspension in [None, Some(Suspension::Second), Some(Suspension::Fourth)] {
+                    let base = configure_builder(root, triad, seventh, extension, suspension);
+                    if let Ok(chord) = base.clone().build() {
+                        register_canonical(&mut symbols, chord);
+                    }
+                    for first in operations {
+                        for second in operations {
+                            let first_builder = match apply(base.clone(), first) {
+                                Ok(builder) => builder,
+                                Err(_) => continue,
+                            };
+                            let second_builder = match apply(first_builder, second) {
+                                Ok(builder) => builder,
+                                Err(_) => continue,
+                            };
+                            if let Ok(chord) = second_builder.build() {
+                                register_canonical(&mut symbols, chord);
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    assert!(symbols.len() > 500, "only {} unique symbols", symbols.len());
+}
+
+#[test]
+fn every_common_root_and_bass_spelling_round_trips_with_correct_state() {
+    let letters = [
+        NoteLetter::C,
+        NoteLetter::D,
+        NoteLetter::E,
+        NoteLetter::F,
+        NoteLetter::G,
+        NoteLetter::A,
+        NoteLetter::B,
+    ];
+    let suffixes = [
+        "", "m", "dim7", "augMaj7", "5", "6/9", "7", "maj9#11", "mMaj13", "7sus4", "add13", "7alt",
+    ];
+
+    for root_letter in letters {
+        for root_alteration in -2..=2 {
+            let root = Pitch::new(root_letter, root_alteration);
+            for suffix in suffixes {
+                let base_symbol = format!("{}{}", root, suffix);
+                let base = Chord::parse(&base_symbol).unwrap();
+                for bass_letter in letters {
+                    for bass_alteration in -2..=2 {
+                        let bass = Pitch::new(bass_letter, bass_alteration);
+                        let symbol = format!("{}/{}", base_symbol, bass);
+                        let chord = Chord::parse(&symbol).unwrap();
+                        let member_index = base
+                            .notes()
+                            .iter()
+                            .position(|note| note.pitch.into_u8() == bass.into_u8());
+                        match member_index {
+                            Some(0) => {
+                                assert_eq!(chord.inversion(), 0, "{}", symbol);
+                                assert_eq!(chord.bass(), None, "{}", symbol);
+                            }
+                            Some(index) => {
+                                assert_eq!(chord.inversion(), index as u8, "{}", symbol);
+                                assert_eq!(
+                                    chord.bass(),
+                                    Some(chord.notes()[0].pitch),
+                                    "{}",
+                                    symbol
+                                );
+                            }
+                            None => {
+                                assert_eq!(chord.inversion(), 0, "{}", symbol);
+                                assert_eq!(chord.bass(), Some(bass), "{}", symbol);
+                                assert!(
+                                    scientific_semitones(&chord.notes()[0])
+                                        < scientific_semitones(&chord.notes()[1]),
+                                    "{}",
+                                    symbol
+                                );
+                            }
+                        }
+                        let canonical = chord.canonical_symbol();
+                        let reparsed = Chord::parse(&canonical).unwrap();
+                        assert_eq!(reparsed.spec(), chord.spec(), "{}", symbol);
+                        assert_eq!(reparsed.notes(), chord.notes(), "{}", symbol);
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn error_position(error: &ChordError) -> Option<usize> {
+    match error {
+        ChordError::InvalidRoot { position }
+        | ChordError::UnexpectedToken { position, .. }
+        | ChordError::InvalidModifierAt { position, .. }
+        | ChordError::ConflictingModifiersAt { position, .. }
+        | ChordError::InvalidSlashBass { position }
+        | ChordError::UnsupportedConstruction { position, .. } => Some(*position),
+        _ => None,
+    }
+}
+
+#[test]
+fn all_generated_error_positions_are_original_utf8_boundaries() {
+    let fragments = [
+        "C", "b", "#", "𝄫", "Δ", "7", "sus", "add", "no", "/", "(", ")", ",", "🎵",
+    ];
+    for first in fragments {
+        for second in fragments {
+            for third in fragments {
+                for fourth in fragments {
+                    let symbol = format!("{}{}{}{}", first, second, third, fourth);
+                    if let Err(error) = Chord::parse(&symbol) {
+                        if let Some(position) = error_position(&error) {
+                            assert!(position <= symbol.len(), "{}: {:?}", symbol, error);
+                            assert!(symbol.is_char_boundary(position), "{}: {:?}", symbol, error);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn adversarial_long_errors_remain_fast_and_positioned() {
+    let symbol = format!("C{}", "w".repeat(16_384));
+    let started = Instant::now();
+    let error = Chord::parse(&symbol).unwrap_err();
+    assert!(started.elapsed() < Duration::from_secs(5));
+    assert!(matches!(
+        error,
+        ChordError::UnexpectedToken { position: 1, .. }
+    ));
+
+    let unicode = format!("C7({})", "♭9,".repeat(4_096));
+    let started = Instant::now();
+    let result = panic::catch_unwind(|| Chord::parse(&unicode));
+    assert!(result.is_ok());
+    assert!(started.elapsed() < Duration::from_secs(5));
+}
+
+#[test]
+fn extreme_chord_octaves_never_panic_and_clamp_midi() {
+    for octave in [i16::MIN, i16::MIN + 1, -1, 0, 9, i16::MAX - 1, i16::MAX] {
+        for symbol in ["Cbmaj13", "B#7alt", "Cbbadd13/F#"] {
+            let chord = Chord::parse(symbol).unwrap().with_octave(octave);
+            let result = panic::catch_unwind(|| chord.notes());
+            assert!(result.is_ok(), "{} octave {}", symbol, octave);
+            for note in result.unwrap() {
+                assert!(note.midi_pitch() <= 127);
+            }
+        }
+    }
+}

--- a/tests/chord/test_regex.rs
+++ b/tests/chord/test_regex.rs
@@ -4,10 +4,10 @@ use theory::note::{Pitch, NoteLetter::*};
 
 fn assert_chords(table: Vec<(&str, Pitch, Quality, Number)>) {
     for (string, pitch, quality, number) in table {
-        let chord = Chord::from_regex(string).unwrap();
-        assert_eq!(chord.quality, quality);
-        assert_eq!(chord.root, pitch);
-        assert_eq!(chord.number, number);
+        let chord = Chord::parse(string).unwrap();
+        assert_eq!(chord.quality(), quality);
+        assert_eq!(chord.root(), pitch);
+        assert_eq!(chord.number(), number);
     }
 }
 
@@ -22,7 +22,7 @@ mod chord_regex_tests {
             ("E MAJOR", Pitch::new(E, 0), Major, Triad),
             ("C Maj", Pitch::new(C, 0), Major, Triad),
             ("Cb MAJ", Pitch::new(C, -1), Major, Triad),
-            ("Cb MAJ Seventh", Pitch::new(C, -1), Major, Seventh),
+            ("Cb MAJ Seventh", Pitch::new(C, -1), Major, MajorSeventh),
             ("C M", Pitch::new(C, 0), Major, Triad),
             ("C MaJ Triad", Pitch::new(C, 0), Major, Triad),
             ("C Major Seventh", Pitch::new(C, 0), Major, MajorSeventh),
@@ -127,10 +127,8 @@ mod chord_regex_tests {
             "C augmented ninth",
             "C diminished ninth",
             "C half diminished triad",
-            "C dominant triad",
-            "C suspended2 seventh",
         ] {
-            assert!(Chord::from_regex(chord).is_err(), "{} should be rejected", chord);
+            assert!(Chord::parse(chord).is_err(), "{} should be rejected", chord);
         }
     }
 }

--- a/tests/cli/test_cli.rs
+++ b/tests/cli/test_cli.rs
@@ -19,8 +19,8 @@ fn lists_every_supported_scale_and_chord() {
 
     let chords = rustmt(&["chord", "list"]);
     assert!(chords.status.success());
-    assert!(stdout(&chords).contains("Minor Ninth"));
-    assert!(stdout(&chords).contains("Minor Thirteenth"));
+    assert!(stdout(&chords).contains("Ninths: C9, Cmaj9, Cm9, CmMaj9"));
+    assert!(stdout(&chords).contains("Altered dominant: C7alt"));
 }
 
 #[test]
@@ -51,4 +51,44 @@ fn prints_non_chord_slash_bass_first() {
 fn rejects_invalid_music_input() {
     assert!(!rustmt(&["chord", "C", "garbage"]).status.success());
     assert!(!rustmt(&["scale", "C", "garbage"]).status.success());
+}
+
+#[test]
+fn accepts_compact_symbols_and_normalizes_aliases() {
+    let chord = rustmt(&["chord", "C7sus4"]);
+    assert!(chord.status.success());
+    assert_eq!(stdout(&chord), "Notes:\n  1: C\n  2: F\n  3: G\n  4: Bb\n");
+
+    let normalized = rustmt(&["chord", "normalize", "C7(b9,#11)"]);
+    assert!(normalized.status.success());
+    assert_eq!(stdout(&normalized), "C7b9#11\n");
+
+    let invalid = rustmt(&["chord", "normalize", "C7altb9"]);
+    assert!(!invalid.status.success());
+    assert!(String::from_utf8(invalid.stderr)
+        .unwrap()
+        .contains("Conflicting chord modifiers"));
+
+    let composed_alias = rustmt(&["chord", "normalize", "C+M7"]);
+    assert!(composed_alias.status.success());
+    assert_eq!(stdout(&composed_alias), "CaugMaj7\n");
+
+    let malformed_group = rustmt(&["chord", "normalize", "C7(b9,,#11)"]);
+    assert!(!malformed_group.status.success());
+    assert!(String::from_utf8(malformed_group.stderr)
+        .unwrap()
+        .contains("Unexpected token"));
+}
+
+#[test]
+fn second_audit_regressions_match_the_rust_parser() {
+    let unicode = rustmt(&["chord", "normalize", "C𝄫maj7"]);
+    assert!(unicode.status.success());
+    assert_eq!(stdout(&unicode), "Cbbmaj7\n");
+
+    for invalid in ["C5add9", "CmMaj6", "Cdom6"] {
+        let result = rustmt(&["chord", "normalize", invalid]);
+        assert!(!result.status.success(), "{} should fail", invalid);
+        assert!(String::from_utf8(result.stderr).unwrap().contains("error:"));
+    }
 }

--- a/tests/midi_integration.rs
+++ b/tests/midi_integration.rs
@@ -140,3 +140,30 @@ fn builder_chaining() {
     let bytes = file.to_bytes();
     assert_eq!(&bytes[0..4], b"MThd");
 }
+
+#[test]
+fn lead_sheet_theoretical_accidentals_export_at_the_correct_midi_octaves() {
+    use midly::{MidiMessage, Smf, TrackEventKind};
+
+    fn exported_pitches(symbol: &str) -> Vec<u8> {
+        let chord = Chord::parse(symbol).unwrap();
+        let bytes = chord
+            .to_midi(Duration::Quarter, Velocity::new(100).unwrap())
+            .to_bytes();
+        let midi = Smf::parse(&bytes).unwrap();
+        midi.tracks
+            .iter()
+            .flat_map(|track| track.iter())
+            .filter_map(|event| match event.kind {
+                TrackEventKind::Midi {
+                    message: MidiMessage::NoteOn { key, vel },
+                    ..
+                } if vel.as_int() > 0 => Some(key.as_int()),
+                _ => None,
+            })
+            .collect()
+    }
+
+    assert_eq!(exported_pitches("Cbmaj7"), [59, 63, 66, 70]);
+    assert_eq!(exported_pitches("B#maj7"), [72, 76, 79, 83]);
+}

--- a/tests/note/test_notes_trait.rs
+++ b/tests/note/test_notes_trait.rs
@@ -10,7 +10,7 @@ mod test_notes_trait {
     #[test]
     fn test_chord_notes_trait() {
         // Test that Chord implements Notes trait
-        let c_major = Chord::from_regex("C major").unwrap();
+        let c_major = Chord::parse("C major").unwrap();
         let notes = c_major.notes();
 
         assert_eq!(notes.len(), 3);
@@ -71,7 +71,7 @@ mod test_notes_trait {
     #[test]
     fn test_chord_notes_with_sharps_and_flats() {
         // Test D minor chord
-        let d_minor = Chord::from_regex("D minor").unwrap();
+        let d_minor = Chord::parse("D minor").unwrap();
         let notes = d_minor.notes();
 
         assert_eq!(notes.len(), 3);
@@ -80,7 +80,7 @@ mod test_notes_trait {
         assert_eq!(notes[2].pitch, Pitch::new(NoteLetter::A, 0));
 
         // Test F# major chord
-        let fs_major = Chord::from_regex("F# major").unwrap();
+        let fs_major = Chord::parse("F# major").unwrap();
         let notes = fs_major.notes();
 
         assert_eq!(notes.len(), 3);
@@ -110,7 +110,7 @@ mod test_notes_trait {
     #[test]
     fn test_seventh_chord_notes() {
         // Test a seventh chord
-        let c_maj7 = Chord::from_regex("C major seventh").unwrap();
+        let c_maj7 = Chord::parse("C major seventh").unwrap();
         let notes = c_maj7.notes();
 
         assert_eq!(notes.len(), 4);
@@ -123,7 +123,7 @@ mod test_notes_trait {
     #[test]
     fn test_diminished_chord_notes() {
         // Test a diminished chord
-        let b_dim = Chord::from_regex("B diminished").unwrap();
+        let b_dim = Chord::parse("B diminished").unwrap();
         let notes = b_dim.notes();
 
         assert_eq!(notes.len(), 3);

--- a/tests/note/test_pitch.rs
+++ b/tests/note/test_pitch.rs
@@ -271,4 +271,14 @@ mod test_note {
         let f_quintuple_sharp = Pitch::new(NoteLetter::F, 5);
         assert_eq!(f_quintuple_sharp.into_u8(), 10); // F##### = Bb
     }
+
+    #[test]
+    fn test_accidental_overflow_is_rejected_and_extremes_format_without_panicking() {
+        let too_many_sharps = format!("C{}", "#".repeat(512));
+        assert!(Pitch::from_str(&too_many_sharps).is_none());
+
+        let lowest = Pitch::new(NoteLetter::C, i8::MIN).to_string();
+        assert_eq!(lowest.len(), 129);
+        assert!(lowest[1..].chars().all(|character| character == 'b'));
+    }
 }

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -4,6 +4,10 @@ mod chord {
     mod test_quality;
     mod test_regex;
     mod test_enharmonics;
+    mod test_lead_sheet;
+    mod test_lead_sheet_audit;
+    mod test_lead_sheet_second_audit;
+    mod test_lead_sheet_third_audit;
 }
 
 mod scale {

--- a/tests/theory/test_reference_theory.rs
+++ b/tests/theory/test_reference_theory.rs
@@ -199,7 +199,7 @@ fn every_supported_chord_formula_is_transposed_and_spelled_by_chord_member() {
             }
 
             let recognized = Chord::from_interval(root, adjacent_intervals).unwrap();
-            assert_eq!((recognized.quality, recognized.number), (quality, number));
+            assert_eq!((recognized.quality(), recognized.number()), (quality, number));
         }
     }
 }
@@ -549,7 +549,7 @@ fn public_parsers_do_not_panic_on_arbitrary_short_input() {
         for second in alphabet {
             for third in alphabet {
                 let input = [first, second, third].iter().collect::<String>();
-                assert!(std::panic::catch_unwind(|| Chord::from_regex(&input)).is_ok());
+                assert!(std::panic::catch_unwind(|| Chord::parse(&input)).is_ok());
                 assert!(std::panic::catch_unwind(|| Scale::from_regex(&input)).is_ok());
                 assert!(std::panic::catch_unwind(|| Pitch::from_str(&input)).is_ok());
             }


### PR DESCRIPTION
## Summary

- replace the fixed chord parser with normalized lead-sheet chord specifications and formulas
- support common jazz/pop aliases, extensions, suspensions, alterations, additions, omissions, power chords, inversions, and slash basses
- expose canonical symbols through Rust, CLI, and WASM while preserving legacy constructors
- preserve exact theoretical note spelling and position-aware UTF-8 parse errors
- document the supported grammar and migration path

## Why

Application developers need practical lead-sheet symbols such as `C7sus4`, `Cm7b5`, `Cmaj9#11/G`, `Cadd9`, `C7no5`, `C7alt`, sixths, power chords, and canonical formatting without manually assembling intervals.

## Reliability

The parser uses normalized validated chord specifications and a linear source-position map. The test suite includes alias/formula/spelling tables, canonical round trips, builder conflict checks, exhaustive root and slash-bass combinations, generated malformed UTF-8 token streams, long adversarial inputs, extreme octaves, CLI behavior, MIDI, and WASM.

## Validation

- `cargo test --all-targets --quiet` - 194 passed
- `cargo test --all-targets --features midi --quiet` - 236 passed
- `cargo test --all-targets --features midi-playback --quiet` - 264 passed, 8 hardware-dependent ignored
- `wasm-pack test --node` - 25 passed
- `RUSTDOCFLAGS='-D warnings' cargo doc --no-deps`
- `cargo test --doc --quiet`
- `wasm-pack build --target web --out-dir target/web-pkg`
- targeted `rustfmt --check`
- `git diff --check`
