### PR TITLE
Complete harmonic and melodic minor modes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,16 @@
+## Unreleased
+
+### Features
+
+- Add every harmonic-minor and melodic-minor mode with canonical names, established aliases,
+  validated scale-family metadata, CLI generation, and WASM identifiers
+
+### Fixes
+
+- Preserve classical melodic-minor descent while derived melodic-minor modes use the jazz pitch
+  collection in both directions
+- Synchronize scale octaves after theoretical respelling so augmented steps remain strictly ordered
+
 ## v0.5.0 - 2026-07-12
 
 ### Features

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ A library and executable that provides programmatic implementation of the basis 
 - [Overview](#overview)
 - [Usage as a Library](#usage-as-a-library)
 - [Lead-Sheet Chord Symbols](#lead-sheet-chord-symbols)
+- [Harmonic and Melodic Minor Modes](#harmonic-and-melodic-minor-modes)
 - [MIDI Support](#midi-support)
 - [Usage as an Executable](#usage-as-an-executable)
 - [Interactive Playground](#interactive-playground)
@@ -100,6 +101,45 @@ octaves follow written scientific pitch, so `Cb4` plays as MIDI 59 and `B#4` as 
 `Chord::builder(root)` exposes the same validated model for programmatic construction. See
 [the chord-symbol reference](docs/chord-symbols.md) for grammar, canonicalization, builder usage,
 errors, and the 0.4 to 0.5 migration.
+
+## Harmonic and Melodic Minor Modes
+
+All seven rotations of the harmonic-minor and melodic-minor families are available through the
+same `Scale`, `ScaleType`, and `Mode` APIs:
+
+```rust
+use rust_music_theory::note::{NoteLetter, Notes, Pitch};
+use rust_music_theory::scale::{Direction, Mode, Scale, ScaleType};
+
+let scale = Scale::new(
+    ScaleType::HarmonicMinor,
+    Pitch::new(NoteLetter::C, 0),
+    4,
+    Some(Mode::PhrygianDominant),
+    Direction::Ascending,
+)?;
+
+assert_eq!(
+    scale.notes().iter().map(|note| note.pitch.to_string()).collect::<Vec<_>>(),
+    ["C", "Db", "E", "F", "G", "Ab", "Bb", "C"]
+);
+# Ok::<(), rust_music_theory::scale::ScaleError>(())
+```
+
+- Harmonic minor: `Harmonic Minor`, `Locrian natural 6`, `Ionian #5`, `Dorian #4`,
+  `Phrygian Dominant`, `Lydian #2`, and `Ultralocrian`.
+- Melodic minor: `Melodic Minor`, `Dorian b2`, `Lydian Augmented`, `Lydian Dominant`,
+  `Mixolydian b6`, `Locrian #2`, and `Altered`.
+
+Names are case-insensitive and accept ASCII or Unicode accidentals, words such as `flat` and
+`sharp`, snake-case API identifiers, and established aliases such as `Spanish`, `Overtone`,
+`Hindu`, `Super Locrian`, and `Diminished Whole Tone`. The definitions follow the
+[Tonal scale registry](https://github.com/tonaljs/tonal/blob/main/packages/scale-type/data.ts).
+
+The existing base melodic-minor scale retains classical behavior: descending it lowers the sixth
+and seventh. Derived melodic-minor modes use the ascending/jazz pitch collection in both
+directions. Altered mode retains rotation-derived diatonic spelling, so C altered is written
+`C Db Eb Fb Gb Ab Bb` rather than using enharmonic chord-tension names.
 
 ## MIDI Support
 
@@ -233,15 +273,32 @@ C7b9#11
 `rustmt scale list`
 ```yaml
 Available Scales:
- - Major|Ionian
- - Minor|Aeolian
+ - Ionian
  - Dorian
  - Phrygian
  - Lydian
  - Mixolydian
+ - Aeolian
  - Locrian
  - Harmonic Minor
+ - Locrian natural 6
+ - Ionian #5
+ - Dorian #4
+ - Phrygian Dominant
+ - Lydian #2
+ - Ultralocrian
  - Melodic Minor
+ - Dorian b2
+ - Lydian Augmented
+ - Lydian Dominant
+ - Mixolydian b6
+ - Locrian #2
+ - Altered
+ - Pentatonic Major
+ - Pentatonic Minor
+ - Blues
+ - Chromatic
+ - Whole Tone
 ```
 
 
@@ -295,7 +352,7 @@ Notes:
 - [x] MIDI Clock (master mode)
 - [x] Properly display enharmonic spelling
 - [x] Add inversion support for chords
-- [ ] Add missing modes for Melodic & Harmonic minor scales
+- [x] Add missing modes for Melodic & Harmonic minor scales
 - [x] Add support for arbitrary accidentals
 - [ ] Add a mechanism to find the chord from the given notes
 - [ ] MIDI input (receive from external devices)

--- a/README.md
+++ b/README.md
@@ -296,6 +296,6 @@ Notes:
 - [x] Properly display enharmonic spelling
 - [x] Add inversion support for chords
 - [ ] Add missing modes for Melodic & Harmonic minor scales
-- [ ] Add support for arbitrary accidentals
+- [x] Add support for arbitrary accidentals
 - [ ] Add a mechanism to find the chord from the given notes
 - [ ] MIDI input (receive from external devices)

--- a/src/bin/rustmt.rs
+++ b/src/bin/rustmt.rs
@@ -1,18 +1,9 @@
 use clap::{App, Arg, ArgMatches};
 use rust_music_theory::chord::{Chord, SUPPORTED_CHORD_SYNTAX};
 use rust_music_theory::note::Notes;
-use rust_music_theory::scale::{Direction, Scale};
+use rust_music_theory::scale::{Direction, Mode, Scale};
 
-const AVAILABLE_SCALES: [&str; 14] = [
-    "Major|Ionian",
-    "Minor|Aeolian",
-    "Dorian",
-    "Phrygian",
-    "Lydian",
-    "Mixolydian",
-    "Locrian",
-    "Harmonic Minor",
-    "Melodic Minor",
+const STANDALONE_SCALES: [&str; 5] = [
     "Pentatonic Major",
     "Pentatonic Minor",
     "Blues",
@@ -20,27 +11,33 @@ const AVAILABLE_SCALES: [&str; 14] = [
     "Whole Tone",
 ];
 
-fn scale_command(scale_matches: &ArgMatches) {
+fn scale_command(scale_matches: &ArgMatches) -> Result<(), String> {
     use Direction::*;
     match scale_matches.subcommand() {
         ("list", _) => {
             println!("Available Scales:");
-            for scale in &AVAILABLE_SCALES {
+            for mode in Mode::heptatonic_modes() {
+                println!(" - {}", mode.canonical_name());
+            }
+            for scale in &STANDALONE_SCALES {
                 println!(" - {}", scale);
             }
+            Ok(())
         }
         _ => {
             let scale_args = scale_matches
                 .values_of("args")
-                .unwrap()
-                .collect::<Vec<_>>()
-                .join(" ");
+                .map(|values| values.collect::<Vec<_>>().join(" "))
+                .filter(|value| !value.trim().is_empty())
+                .ok_or_else(|| "missing scale".to_string())?;
 
             let descending = scale_matches.is_present("descending");
             let direction = if descending { Descending } else { Ascending };
 
-            let scale = Scale::from_regex_in_direction(&scale_args, direction).unwrap();
+            let scale = Scale::from_regex_in_direction(&scale_args, direction)
+                .map_err(|error| error.to_string())?;
             scale.print_notes();
+            Ok(())
         }
     }
 }
@@ -121,10 +118,7 @@ fn main() {
         .get_matches();
 
     let result = match matches.subcommand() {
-        ("scale", Some(scale_matches)) => {
-            scale_command(scale_matches);
-            Ok(())
-        }
+        ("scale", Some(scale_matches)) => scale_command(scale_matches),
 
         ("chord", Some(chord_matches)) => chord_command(chord_matches),
 

--- a/src/scale.rs
+++ b/src/scale.rs
@@ -1,11 +1,33 @@
-//! Scales.
+//! Scales and modes.
+//!
+//! The seven modes of the major, harmonic-minor, and melodic-minor families preserve generic
+//! letter spelling, including theoretical double accidentals.
+//!
+//! ```
+//! use rust_music_theory::note::{NoteLetter, Notes, Pitch};
+//! use rust_music_theory::scale::{Direction, Mode, Scale, ScaleType};
+//!
+//! let scale = Scale::new(
+//!     ScaleType::MelodicMinor,
+//!     Pitch::new(NoteLetter::C, 0),
+//!     4,
+//!     Some(Mode::Altered),
+//!     Direction::Ascending,
+//! ).unwrap();
+//! let pitches = scale
+//!     .notes()
+//!     .iter()
+//!     .map(|note| note.pitch.to_string())
+//!     .collect::<Vec<_>>();
+//! assert_eq!(pitches, ["C", "Db", "Eb", "Fb", "Gb", "Ab", "Bb", "C"]);
+//! ```
 
 mod errors;
 mod mode;
 mod scale;
 mod scale_type;
 
-pub use mode::Mode;
 pub use errors::ScaleError;
+pub use mode::Mode;
 pub use scale::{Direction, Scale};
 pub use scale_type::ScaleType;

--- a/src/scale/errors.rs
+++ b/src/scale/errors.rs
@@ -1,13 +1,15 @@
 use crate::interval::IntervalError;
 use crate::note::NoteError;
+use crate::scale::{Mode, ScaleType};
 use std::error;
 use std::fmt;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum ScaleError {
     InvalidInterval,
     ModeFromRegex,
     InvalidRegex,
+    IncompatibleMode { scale_type: ScaleType, mode: Mode },
 }
 
 impl fmt::Display for ScaleError {
@@ -18,6 +20,13 @@ impl fmt::Display for ScaleError {
             }
             ScaleError::ModeFromRegex => write!(f, "Can't determine the mode!"),
             ScaleError::InvalidRegex => write!(f, "Invalid scale regex!"),
+            ScaleError::IncompatibleMode { scale_type, mode } => write!(
+                f,
+                "Mode {} belongs to {}, not {}",
+                mode.canonical_name(),
+                mode.scale_type(),
+                scale_type
+            ),
         }
     }
 }

--- a/src/scale/mode.rs
+++ b/src/scale/mode.rs
@@ -11,7 +11,7 @@ lazy_static! {
 }
 
 /// The mode of a scale.
-#[derive(Display, Debug, Clone, Copy, EnumIter, PartialEq, Eq)]
+#[derive(Display, Debug, Clone, Copy, EnumIter, PartialEq, Eq, Hash)]
 pub enum Mode {
     /// Also known as a major scale.
     Ionian,
@@ -379,5 +379,48 @@ impl FromStr for Mode {
                     })
             })
             .ok_or(ModeFromRegex)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::{HashMap, HashSet};
+
+    #[test]
+    fn every_registered_alias_is_unique_and_round_trips() {
+        let mut owners = HashMap::new();
+        for mode in ALL_MODES.iter().copied() {
+            for name in std::iter::once(mode.canonical_name())
+                .chain(std::iter::once(mode.api_name()))
+                .chain(mode.aliases().iter().copied())
+            {
+                assert_eq!(name.parse::<Mode>().unwrap(), mode, "alias {name}");
+                let normalized = normalize_mode_name(name);
+                if let Some(previous) = owners.insert(normalized.clone(), mode) {
+                    assert_eq!(
+                        previous, mode,
+                        "normalized alias {normalized} belongs to two modes"
+                    );
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn heptatonic_registry_contains_twenty_one_unique_modes() {
+        assert_eq!(HEPTATONIC_MODES.len(), 21);
+        assert_eq!(
+            HEPTATONIC_MODES
+                .iter()
+                .copied()
+                .collect::<HashSet<_>>()
+                .len(),
+            21
+        );
+        assert!(HEPTATONIC_MODES.iter().all(|mode| matches!(
+            mode.scale_type(),
+            ScaleType::Diatonic | ScaleType::HarmonicMinor | ScaleType::MelodicMinor
+        )));
     }
 }

--- a/src/scale/mode.rs
+++ b/src/scale/mode.rs
@@ -1,54 +1,13 @@
 use crate::scale::errors::ScaleError;
 use crate::scale::errors::ScaleError::ModeFromRegex;
-use crate::scale::mode::Mode::*;
+use crate::scale::ScaleType;
 use lazy_static::lazy_static;
 use regex::{Match, Regex};
+use std::str::FromStr;
 use strum_macros::{Display, EnumIter};
 
 lazy_static! {
-    static ref MODE_REGEXES: Vec<(Regex, Mode)> = vec![
-        (
-            Regex::new(r"^(M\s+|M$|(?i)maj|major|ionian)").unwrap(),
-            Ionian
-        ),
-        (
-            Regex::new(r"(?i)(har minor|harmonicminor|harmonic\s+minor)").unwrap(),
-            HarmonicMinor
-        ),
-        (
-            Regex::new(r"(?i)(mel minor|melodicminor|melodic\s+minor)").unwrap(),
-            MelodicMinor
-        ),
-        (
-            Regex::new(r"(?i)(pentatonic\s+major|pentatonic\s+maj|pent\s+maj|pent\s+major)").unwrap(),
-            PentatonicMajor
-        ),
-        (
-            Regex::new(r"(?i)(pentatonic\s+minor|pentatonic\s+min|pent\s+min|pent\s+minor)").unwrap(),
-            PentatonicMinor
-        ),
-        (
-            Regex::new(r"(?i)(blues)").unwrap(),
-            Blues
-        ),
-        (
-            Regex::new(r"(?i)(chromatic)").unwrap(),
-            Chromatic
-        ),
-        (
-            Regex::new(r"(?i)(whole\s+tone|wholetone)").unwrap(),
-            WholeTone
-        ),
-        (
-            Regex::new(r"^(m\s+|m$|(?i)min|minor|aeolian)").unwrap(),
-            Aeolian
-        ),
-        (Regex::new(r"(?i)^(dorian)").unwrap(), Dorian),
-        (Regex::new(r"(?i)^(locrian)").unwrap(), Locrian),
-        (Regex::new(r"(?i)^(mixolydian)").unwrap(), Mixolydian),
-        (Regex::new(r"(?i)^(phrygian)").unwrap(), Phrygian),
-        (Regex::new(r"(?i)^(lydian)").unwrap(), Lydian),
-    ];
+    static ref MODE_TEXT_REGEX: Regex = Regex::new(r"(?s)\S(?:.*\S)?").unwrap();
 }
 
 /// The mode of a scale.
@@ -64,6 +23,12 @@ pub enum Mode {
     Aeolian,
     Locrian,
     HarmonicMinor,
+    LocrianNatural6,
+    IonianSharp5,
+    DorianSharp4,
+    PhrygianDominant,
+    LydianSharp2,
+    UltraLocrian,
     MelodicMinor,
     PentatonicMajor,
     PentatonicMinor,
@@ -72,24 +37,277 @@ pub enum Mode {
     WholeTone,
 }
 
-impl Mode {
-    /// Parse a mode using a regex.
-    pub fn from_regex(string: &str) -> Result<(Self, Match<'_>), ScaleError> {
-        for (regex, mode_enum) in &*MODE_REGEXES {
-            let mode = regex.find(string.trim());
+const ALL_MODES: &[Mode] = &[
+    Mode::Ionian,
+    Mode::Dorian,
+    Mode::Phrygian,
+    Mode::Lydian,
+    Mode::Mixolydian,
+    Mode::Aeolian,
+    Mode::Locrian,
+    Mode::HarmonicMinor,
+    Mode::LocrianNatural6,
+    Mode::IonianSharp5,
+    Mode::DorianSharp4,
+    Mode::PhrygianDominant,
+    Mode::LydianSharp2,
+    Mode::UltraLocrian,
+    Mode::MelodicMinor,
+    Mode::PentatonicMajor,
+    Mode::PentatonicMinor,
+    Mode::Blues,
+    Mode::Chromatic,
+    Mode::WholeTone,
+];
 
-            if let Some(mode_match) = mode {
-                return Ok((*mode_enum, mode_match));
-            };
+fn normalize_mode_name(input: &str) -> String {
+    let mut text = String::new();
+    for character in input.trim().chars() {
+        match character {
+            '♭' => text.push('b'),
+            '♯' => text.push('#'),
+            '♮' => text.push_str(" natural "),
+            '-' | '_' => text.push(' '),
+            character => text.extend(character.to_lowercase()),
         }
-
-        Err(ModeFromRegex)
     }
 
-    /// Get whether the mode is diatonic (not harmonic or melodic minor).
+    let raw_tokens = text.split_whitespace().collect::<Vec<_>>();
+    let mut tokens = Vec::new();
+    let mut index = 0;
+    while index < raw_tokens.len() {
+        let token = match raw_tokens[index] {
+            "flat" => "b".to_string(),
+            "sharp" => "#".to_string(),
+            "nat" | "natural" => "natural".to_string(),
+            token
+                if token.starts_with("flat")
+                    && token[4..].chars().all(|ch| ch.is_ascii_digit()) =>
+            {
+                format!("b{}", &token[4..])
+            }
+            token
+                if token.starts_with("sharp")
+                    && token[5..].chars().all(|ch| ch.is_ascii_digit()) =>
+            {
+                format!("#{}", &token[5..])
+            }
+            token
+                if token.starts_with("nat") && token[3..].chars().all(|ch| ch.is_ascii_digit()) =>
+            {
+                format!("natural{}", &token[3..])
+            }
+            token => token.to_string(),
+        };
+
+        if matches!(token.as_str(), "b" | "#" | "natural")
+            && raw_tokens
+                .get(index + 1)
+                .map(|next| next.chars().all(|ch| ch.is_ascii_digit()))
+                .unwrap_or(false)
+        {
+            tokens.push(format!("{}{}", token, raw_tokens[index + 1]));
+            index += 2;
+        } else {
+            tokens.push(token);
+            index += 1;
+        }
+    }
+
+    tokens.join(" ")
+}
+
+impl Mode {
+    /// The scale family whose interval pattern produces this mode.
+    pub fn scale_type(self) -> ScaleType {
+        match self {
+            Self::Ionian
+            | Self::Dorian
+            | Self::Phrygian
+            | Self::Lydian
+            | Self::Mixolydian
+            | Self::Aeolian
+            | Self::Locrian => ScaleType::Diatonic,
+            Self::HarmonicMinor
+            | Self::LocrianNatural6
+            | Self::IonianSharp5
+            | Self::DorianSharp4
+            | Self::PhrygianDominant
+            | Self::LydianSharp2
+            | Self::UltraLocrian => ScaleType::HarmonicMinor,
+            Self::MelodicMinor => ScaleType::MelodicMinor,
+            Self::PentatonicMajor => ScaleType::PentatonicMajor,
+            Self::PentatonicMinor => ScaleType::PentatonicMinor,
+            Self::Blues => ScaleType::Blues,
+            Self::Chromatic => ScaleType::Chromatic,
+            Self::WholeTone => ScaleType::WholeTone,
+        }
+    }
+
+    /// The zero-based rotation of this mode within its scale family.
+    pub fn rotation(self) -> usize {
+        match self {
+            Self::Ionian | Self::HarmonicMinor | Self::MelodicMinor => 0,
+            Self::Dorian | Self::LocrianNatural6 => 1,
+            Self::Phrygian | Self::IonianSharp5 => 2,
+            Self::Lydian | Self::DorianSharp4 => 3,
+            Self::Mixolydian | Self::PhrygianDominant => 4,
+            Self::Aeolian | Self::LydianSharp2 => 5,
+            Self::Locrian | Self::UltraLocrian => 6,
+            Self::PentatonicMajor
+            | Self::PentatonicMinor
+            | Self::Blues
+            | Self::Chromatic
+            | Self::WholeTone => 0,
+        }
+    }
+
+    /// The canonical human-readable ASCII name of this mode.
+    pub fn canonical_name(self) -> &'static str {
+        match self {
+            Self::Ionian => "Ionian",
+            Self::Dorian => "Dorian",
+            Self::Phrygian => "Phrygian",
+            Self::Lydian => "Lydian",
+            Self::Mixolydian => "Mixolydian",
+            Self::Aeolian => "Aeolian",
+            Self::Locrian => "Locrian",
+            Self::HarmonicMinor => "Harmonic Minor",
+            Self::LocrianNatural6 => "Locrian natural 6",
+            Self::IonianSharp5 => "Ionian #5",
+            Self::DorianSharp4 => "Dorian #4",
+            Self::PhrygianDominant => "Phrygian Dominant",
+            Self::LydianSharp2 => "Lydian #2",
+            Self::UltraLocrian => "Ultralocrian",
+            Self::MelodicMinor => "Melodic Minor",
+            Self::PentatonicMajor => "Pentatonic Major",
+            Self::PentatonicMinor => "Pentatonic Minor",
+            Self::Blues => "Blues",
+            Self::Chromatic => "Chromatic",
+            Self::WholeTone => "Whole Tone",
+        }
+    }
+
+    /// The stable snake-case identifier used by WASM and other serialized APIs.
+    pub fn api_name(self) -> &'static str {
+        match self {
+            Self::Ionian => "ionian",
+            Self::Dorian => "dorian",
+            Self::Phrygian => "phrygian",
+            Self::Lydian => "lydian",
+            Self::Mixolydian => "mixolydian",
+            Self::Aeolian => "aeolian",
+            Self::Locrian => "locrian",
+            Self::HarmonicMinor => "harmonic_minor",
+            Self::LocrianNatural6 => "locrian_natural_6",
+            Self::IonianSharp5 => "ionian_sharp_5",
+            Self::DorianSharp4 => "dorian_sharp_4",
+            Self::PhrygianDominant => "phrygian_dominant",
+            Self::LydianSharp2 => "lydian_sharp_2",
+            Self::UltraLocrian => "ultralocrian",
+            Self::MelodicMinor => "melodic_minor",
+            Self::PentatonicMajor => "pentatonic_major",
+            Self::PentatonicMinor => "pentatonic_minor",
+            Self::Blues => "blues",
+            Self::Chromatic => "chromatic",
+            Self::WholeTone => "whole_tone",
+        }
+    }
+
+    fn aliases(self) -> &'static [&'static str] {
+        match self {
+            Self::Ionian => &["ionian", "major", "maj"],
+            Self::Dorian => &["dorian"],
+            Self::Phrygian => &["phrygian"],
+            Self::Lydian => &["lydian"],
+            Self::Mixolydian => &["mixolydian", "dominant"],
+            Self::Aeolian => &["aeolian", "minor", "min"],
+            Self::Locrian => &["locrian"],
+            Self::HarmonicMinor => &["harmonic minor", "harmonicminor", "har minor"],
+            Self::LocrianNatural6 => &[
+                "locrian natural 6",
+                "locrian nat 6",
+                "locrian 6",
+                "locrian natural sixth",
+            ],
+            Self::IonianSharp5 => &[
+                "ionian #5",
+                "ionian augmented",
+                "major augmented",
+                "major #5",
+            ],
+            Self::DorianSharp4 => &[
+                "dorian #4",
+                "ukrainian dorian",
+                "romanian minor",
+                "altered dorian",
+            ],
+            Self::PhrygianDominant => &["phrygian dominant", "spanish", "phrygian major"],
+            Self::LydianSharp2 => &["lydian #2", "lydian #9"],
+            Self::UltraLocrian => &[
+                "ultralocrian",
+                "ultra locrian",
+                "super locrian bb7",
+                "superlocrian bb7",
+                "super locrian diminished",
+                "superlocrian diminished",
+            ],
+            Self::MelodicMinor => &["melodic minor", "melodicminor", "mel minor", "jazz minor"],
+            Self::PentatonicMajor => &[
+                "pentatonic major",
+                "pentatonic maj",
+                "pent major",
+                "pent maj",
+            ],
+            Self::PentatonicMinor => &[
+                "pentatonic minor",
+                "pentatonic min",
+                "pent minor",
+                "pent min",
+            ],
+            Self::Blues => &["blues"],
+            Self::Chromatic => &["chromatic"],
+            Self::WholeTone => &["whole tone", "wholetone"],
+        }
+    }
+
+    /// Parse a mode while retaining the matched source span for compatibility.
+    pub fn from_regex(string: &str) -> Result<(Self, Match<'_>), ScaleError> {
+        let mode_match = MODE_TEXT_REGEX.find(string).ok_or(ModeFromRegex)?;
+        let mode = Self::from_str(mode_match.as_str())?;
+        Ok((mode, mode_match))
+    }
+
+    /// Get whether this belongs to the seven modes of the major scale.
     pub fn is_diatonic(self) -> bool {
-        !matches!(self, Self::HarmonicMinor | Self::MelodicMinor | 
-                      Self::PentatonicMajor | Self::PentatonicMinor | 
-                      Self::Blues | Self::Chromatic | Self::WholeTone)
+        self.scale_type() == ScaleType::Diatonic
+    }
+}
+
+impl FromStr for Mode {
+    type Err = ScaleError;
+
+    fn from_str(input: &str) -> Result<Self, Self::Err> {
+        let trimmed = input.trim();
+        if trimmed == "M" {
+            return Ok(Self::Ionian);
+        }
+        if trimmed == "m" {
+            return Ok(Self::Aeolian);
+        }
+
+        let normalized = normalize_mode_name(trimmed);
+        let compact = normalized.replace(' ', "");
+        ALL_MODES
+            .iter()
+            .copied()
+            .find(|mode| {
+                mode.api_name().replace('_', " ") == normalized
+                    || mode.aliases().iter().any(|alias| {
+                        let alias = normalize_mode_name(alias);
+                        alias == normalized || alias.replace(' ', "") == compact
+                    })
+            })
+            .ok_or(ModeFromRegex)
     }
 }

--- a/src/scale/mode.rs
+++ b/src/scale/mode.rs
@@ -72,6 +72,30 @@ const ALL_MODES: &[Mode] = &[
     Mode::WholeTone,
 ];
 
+const HEPTATONIC_MODES: &[Mode] = &[
+    Mode::Ionian,
+    Mode::Dorian,
+    Mode::Phrygian,
+    Mode::Lydian,
+    Mode::Mixolydian,
+    Mode::Aeolian,
+    Mode::Locrian,
+    Mode::HarmonicMinor,
+    Mode::LocrianNatural6,
+    Mode::IonianSharp5,
+    Mode::DorianSharp4,
+    Mode::PhrygianDominant,
+    Mode::LydianSharp2,
+    Mode::UltraLocrian,
+    Mode::MelodicMinor,
+    Mode::DorianFlat2,
+    Mode::LydianAugmented,
+    Mode::LydianDominant,
+    Mode::MixolydianFlat6,
+    Mode::LocrianSharp2,
+    Mode::Altered,
+];
+
 fn normalize_mode_name(input: &str) -> String {
     let mut text = String::new();
     for character in input.trim().chars() {
@@ -130,6 +154,11 @@ fn normalize_mode_name(input: &str) -> String {
 }
 
 impl Mode {
+    /// Every supported seven-note mode, grouped by parent scale family.
+    pub fn heptatonic_modes() -> &'static [Self] {
+        HEPTATONIC_MODES
+    }
+
     /// The scale family whose interval pattern produces this mode.
     pub fn scale_type(self) -> ScaleType {
         match self {

--- a/src/scale/mode.rs
+++ b/src/scale/mode.rs
@@ -30,6 +30,12 @@ pub enum Mode {
     LydianSharp2,
     UltraLocrian,
     MelodicMinor,
+    DorianFlat2,
+    LydianAugmented,
+    LydianDominant,
+    MixolydianFlat6,
+    LocrianSharp2,
+    Altered,
     PentatonicMajor,
     PentatonicMinor,
     Blues,
@@ -53,6 +59,12 @@ const ALL_MODES: &[Mode] = &[
     Mode::LydianSharp2,
     Mode::UltraLocrian,
     Mode::MelodicMinor,
+    Mode::DorianFlat2,
+    Mode::LydianAugmented,
+    Mode::LydianDominant,
+    Mode::MixolydianFlat6,
+    Mode::LocrianSharp2,
+    Mode::Altered,
     Mode::PentatonicMajor,
     Mode::PentatonicMinor,
     Mode::Blues,
@@ -135,7 +147,13 @@ impl Mode {
             | Self::PhrygianDominant
             | Self::LydianSharp2
             | Self::UltraLocrian => ScaleType::HarmonicMinor,
-            Self::MelodicMinor => ScaleType::MelodicMinor,
+            Self::MelodicMinor
+            | Self::DorianFlat2
+            | Self::LydianAugmented
+            | Self::LydianDominant
+            | Self::MixolydianFlat6
+            | Self::LocrianSharp2
+            | Self::Altered => ScaleType::MelodicMinor,
             Self::PentatonicMajor => ScaleType::PentatonicMajor,
             Self::PentatonicMinor => ScaleType::PentatonicMinor,
             Self::Blues => ScaleType::Blues,
@@ -148,12 +166,12 @@ impl Mode {
     pub fn rotation(self) -> usize {
         match self {
             Self::Ionian | Self::HarmonicMinor | Self::MelodicMinor => 0,
-            Self::Dorian | Self::LocrianNatural6 => 1,
-            Self::Phrygian | Self::IonianSharp5 => 2,
-            Self::Lydian | Self::DorianSharp4 => 3,
-            Self::Mixolydian | Self::PhrygianDominant => 4,
-            Self::Aeolian | Self::LydianSharp2 => 5,
-            Self::Locrian | Self::UltraLocrian => 6,
+            Self::Dorian | Self::LocrianNatural6 | Self::DorianFlat2 => 1,
+            Self::Phrygian | Self::IonianSharp5 | Self::LydianAugmented => 2,
+            Self::Lydian | Self::DorianSharp4 | Self::LydianDominant => 3,
+            Self::Mixolydian | Self::PhrygianDominant | Self::MixolydianFlat6 => 4,
+            Self::Aeolian | Self::LydianSharp2 | Self::LocrianSharp2 => 5,
+            Self::Locrian | Self::UltraLocrian | Self::Altered => 6,
             Self::PentatonicMajor
             | Self::PentatonicMinor
             | Self::Blues
@@ -180,6 +198,12 @@ impl Mode {
             Self::LydianSharp2 => "Lydian #2",
             Self::UltraLocrian => "Ultralocrian",
             Self::MelodicMinor => "Melodic Minor",
+            Self::DorianFlat2 => "Dorian b2",
+            Self::LydianAugmented => "Lydian Augmented",
+            Self::LydianDominant => "Lydian Dominant",
+            Self::MixolydianFlat6 => "Mixolydian b6",
+            Self::LocrianSharp2 => "Locrian #2",
+            Self::Altered => "Altered",
             Self::PentatonicMajor => "Pentatonic Major",
             Self::PentatonicMinor => "Pentatonic Minor",
             Self::Blues => "Blues",
@@ -206,6 +230,12 @@ impl Mode {
             Self::LydianSharp2 => "lydian_sharp_2",
             Self::UltraLocrian => "ultralocrian",
             Self::MelodicMinor => "melodic_minor",
+            Self::DorianFlat2 => "dorian_flat_2",
+            Self::LydianAugmented => "lydian_augmented",
+            Self::LydianDominant => "lydian_dominant",
+            Self::MixolydianFlat6 => "mixolydian_flat_6",
+            Self::LocrianSharp2 => "locrian_sharp_2",
+            Self::Altered => "altered",
             Self::PentatonicMajor => "pentatonic_major",
             Self::PentatonicMinor => "pentatonic_minor",
             Self::Blues => "blues",
@@ -253,6 +283,17 @@ impl Mode {
                 "superlocrian diminished",
             ],
             Self::MelodicMinor => &["melodic minor", "melodicminor", "mel minor", "jazz minor"],
+            Self::DorianFlat2 => &["dorian b2", "phrygian #6", "melodic minor second mode"],
+            Self::LydianAugmented => &["lydian augmented", "lydian #5"],
+            Self::LydianDominant => &["lydian dominant", "lydian b7", "overtone"],
+            Self::MixolydianFlat6 => &["mixolydian b6", "melodic minor fifth mode", "hindu"],
+            Self::LocrianSharp2 => &["locrian #2", "half diminished", "aeolian b5"],
+            Self::Altered => &[
+                "altered",
+                "super locrian",
+                "superlocrian",
+                "diminished whole tone",
+            ],
             Self::PentatonicMajor => &[
                 "pentatonic major",
                 "pentatonic maj",
@@ -302,7 +343,7 @@ impl FromStr for Mode {
             .iter()
             .copied()
             .find(|mode| {
-                mode.api_name().replace('_', " ") == normalized
+                normalize_mode_name(mode.api_name()) == normalized
                     || mode.aliases().iter().any(|alias| {
                         let alias = normalize_mode_name(alias);
                         alias == normalized || alias.replace(' ', "") == compact

--- a/src/scale/scale.rs
+++ b/src/scale/scale.rs
@@ -11,6 +11,32 @@ pub enum Direction {
     Descending,
 }
 
+fn raw_midi(note: &Note) -> i32 {
+    use NoteLetter::*;
+    let natural = match note.pitch.letter {
+        C => 0,
+        D => 2,
+        E => 4,
+        F => 5,
+        G => 7,
+        A => 9,
+        B => 11,
+    };
+    (note.octave as i32 + 1) * 12 + natural + note.pitch.accidental as i32
+}
+
+fn synchronize_octaves(notes: &mut [Note], direction: Direction) {
+    for index in 1..notes.len() {
+        let previous = raw_midi(&notes[index - 1]);
+        let pitch_value = raw_midi(&Note::new(notes[index].pitch, -1));
+        let octave_plus_one = match direction {
+            Direction::Ascending => (previous - pitch_value).div_euclid(12) + 1,
+            Direction::Descending => (previous - 1 - pitch_value).div_euclid(12),
+        };
+        notes[index].octave = (octave_plus_one - 1).clamp(i16::MIN as i32, i16::MAX as i32) as i16;
+    }
+}
+
 /// A scale.
 #[derive(Debug, Clone)]
 pub struct Scale {
@@ -37,14 +63,23 @@ impl Scale {
         mode: Option<Mode>,
         direction: Direction,
     ) -> Result<Self, ScaleError> {
+        if let Some(mode) = mode {
+            if mode.scale_type() != scale_type {
+                return Err(ScaleError::IncompatibleMode { scale_type, mode });
+            }
+        }
+
+        let classical_melodic_descent = scale_type == ScaleType::MelodicMinor
+            && direction == Direction::Descending
+            && mode.map(Mode::rotation).unwrap_or(0) == 0;
         let mut intervals = match scale_type {
             ScaleType::Diatonic => Interval::from_semitones(&[2, 2, 1, 2, 2, 2, 1]),
             ScaleType::HarmonicMinor => Interval::from_semitones(&[2, 1, 2, 2, 1, 3, 1]),
-            ScaleType::MelodicMinor => match direction {
-                Direction::Ascending => Interval::from_semitones(&[2, 1, 2, 2, 2, 2, 1]),
-                // Classical melodic minor descends as natural minor.
-                Direction::Descending => Interval::from_semitones(&[2, 1, 2, 2, 1, 2, 2]),
-            },
+            ScaleType::MelodicMinor if classical_melodic_descent => {
+                // Preserve the classical base scale: it descends as natural minor.
+                Interval::from_semitones(&[2, 1, 2, 2, 1, 2, 2])
+            }
+            ScaleType::MelodicMinor => Interval::from_semitones(&[2, 1, 2, 2, 2, 2, 1]),
             ScaleType::PentatonicMajor => Interval::from_semitones(&[2, 2, 3, 2, 3]),
             ScaleType::PentatonicMinor => Interval::from_semitones(&[3, 2, 2, 3, 2]),
             ScaleType::Blues => Interval::from_semitones(&[3, 2, 1, 1, 3, 2]),
@@ -142,6 +177,7 @@ impl Notes for Scale {
             }
             notes.first_mut().unwrap().pitch = self.tonic;
             notes.last_mut().unwrap().pitch = self.tonic;
+            synchronize_octaves(&mut notes, self.direction);
             return notes;
         }
 
@@ -151,6 +187,7 @@ impl Notes for Scale {
             }
             notes.first_mut().unwrap().pitch = self.tonic;
             notes.last_mut().unwrap().pitch = self.tonic;
+            synchronize_octaves(&mut notes, self.direction);
             return notes;
         }
 
@@ -183,6 +220,8 @@ impl Notes for Scale {
             let letter = self.tonic.letter.offset(degree_offset);
             note.pitch = Pitch::from_u8_with_letter(note.pitch.into_u8(), letter);
         }
+
+        synchronize_octaves(&mut notes, self.direction);
 
         notes
     }

--- a/src/scale/scale.rs
+++ b/src/scale/scale.rs
@@ -1,7 +1,6 @@
 use crate::interval::Interval;
 use crate::note::{Note, NoteLetter, Notes, Pitch};
 use crate::scale::errors::ScaleError;
-use crate::scale::Mode::{Aeolian, Dorian, Ionian, Locrian, Lydian, Mixolydian, Phrygian};
 use crate::scale::{Mode, ScaleType};
 use strum_macros::Display;
 
@@ -53,27 +52,11 @@ impl Scale {
             ScaleType::WholeTone => Interval::from_semitones(&[2, 2, 2, 2, 2, 2]),
         }?;
 
-        match mode {
-            None => {}
-            Some(mode) => {
-                match mode {
-                    Ionian => {}
-                    Dorian => intervals.rotate_left(1),
-                    Phrygian => intervals.rotate_left(2),
-                    Lydian => intervals.rotate_left(3),
-                    Mixolydian => intervals.rotate_left(4),
-                    Aeolian => intervals.rotate_right(2),
-                    Locrian => intervals.rotate_right(1),
-                    // New scale types don't have modal variations
-                    Mode::PentatonicMajor
-                    | Mode::PentatonicMinor
-                    | Mode::Blues
-                    | Mode::Chromatic
-                    | Mode::WholeTone => {}
-                    _ => {}
-                };
+        if let Some(mode) = mode {
+            if mode.scale_type() == scale_type {
+                intervals.rotate_left(mode.rotation());
             }
-        };
+        }
 
         Ok(Scale {
             tonic,
@@ -214,7 +197,7 @@ impl Default for Scale {
             },
             octave: 0,
             scale_type: ScaleType::Diatonic,
-            mode: Some(Ionian),
+            mode: Some(Mode::Ionian),
             intervals: vec![],
             direction: Direction::Ascending,
         }

--- a/src/scale/scale_type.rs
+++ b/src/scale/scale_type.rs
@@ -1,4 +1,4 @@
-use crate::scale::{Mode, Mode::*};
+use crate::scale::Mode;
 use strum_macros::{Display, EnumIter};
 
 /// The type of a scale.
@@ -17,19 +17,7 @@ pub enum ScaleType {
 impl ScaleType {
     /// Get the scale type from the mode.
     pub fn from_mode(mode: Mode) -> Self {
-        use ScaleType::*;
-        match mode {
-            Ionian => Diatonic,
-            Aeolian => Diatonic,
-            Mode::HarmonicMinor => ScaleType::HarmonicMinor,
-            Mode::MelodicMinor => ScaleType::MelodicMinor,
-            Mode::PentatonicMajor => ScaleType::PentatonicMajor,
-            Mode::PentatonicMinor => ScaleType::PentatonicMinor,
-            Mode::Blues => ScaleType::Blues,
-            Mode::Chromatic => ScaleType::Chromatic,
-            Mode::WholeTone => ScaleType::WholeTone,
-            _ => Diatonic,
-        }
+        mode.scale_type()
     }
 }
 

--- a/src/wasm/parsers.rs
+++ b/src/wasm/parsers.rs
@@ -43,16 +43,7 @@ pub fn parse_scale_type(input: &str) -> ScaleType {
 
 /// Parse a string representation of a mode into a Mode
 pub fn parse_mode(input: &str) -> Option<Mode> {
-    match input.to_lowercase().as_str() {
-        "ionian" => Some(Mode::Ionian),
-        "dorian" => Some(Mode::Dorian),
-        "phrygian" => Some(Mode::Phrygian),
-        "lydian" => Some(Mode::Lydian),
-        "mixolydian" => Some(Mode::Mixolydian),
-        "aeolian" => Some(Mode::Aeolian),
-        "locrian" => Some(Mode::Locrian),
-        _ => None,
-    }
+    input.parse().ok()
 }
 
 /// Parse a string representation of a chord quality into a ChordQuality
@@ -130,6 +121,12 @@ mod tests {
         assert_eq!(parse_mode("mixolydian"), Some(Mode::Mixolydian));
         assert_eq!(parse_mode("aeolian"), Some(Mode::Aeolian));
         assert_eq!(parse_mode("locrian"), Some(Mode::Locrian));
+        assert_eq!(
+            parse_mode("phrygian_dominant"),
+            Some(Mode::PhrygianDominant)
+        );
+        assert_eq!(parse_mode("Dorian ♭2"), Some(Mode::DorianFlat2));
+        assert_eq!(parse_mode("super locrian"), Some(Mode::Altered));
         assert_eq!(parse_mode("invalid"), None);
     }
 

--- a/src/wasm/scales.rs
+++ b/src/wasm/scales.rs
@@ -1,7 +1,7 @@
 use super::parsers::{parse_mode, parse_pitch_symbol, parse_scale_type};
 use super::types::{WasmNote, WasmScale};
 use crate::note::{Notes, Pitch};
-use crate::scale::{Direction, Scale};
+use crate::scale::{Direction, Mode, Scale};
 use wasm_bindgen::prelude::*;
 
 /// Generate a scale from WASM-compatible parameters
@@ -15,7 +15,13 @@ pub fn generate_scale(
 ) -> JsValue {
     let pitch_symbol = parse_pitch_symbol(tonic);
     let scale_type_enum = parse_scale_type(scale_type);
-    let mode_enum = mode.as_ref().and_then(|m| parse_mode(m));
+    let mode_enum = match mode.as_deref() {
+        Some(mode) => match parse_mode(mode) {
+            Some(mode) => Some(mode),
+            None => return JsValue::NULL,
+        },
+        None => None,
+    };
     let direction = if ascending {
         Direction::Ascending
     } else {
@@ -35,7 +41,7 @@ pub fn generate_scale(
                 notes,
                 scale_type: scale_type.to_string(),
                 tonic: tonic.to_string(),
-                mode,
+                mode: mode_enum.map(|mode| mode.api_name().to_string()),
                 direction: if ascending {
                     "ascending".to_string()
                 } else {
@@ -67,15 +73,10 @@ pub fn get_available_scales() -> JsValue {
 /// Get list of available modes
 #[wasm_bindgen]
 pub fn get_available_modes() -> JsValue {
-    let modes = vec![
-        "ionian",
-        "dorian",
-        "phrygian",
-        "lydian",
-        "mixolydian",
-        "aeolian",
-        "locrian",
-    ];
+    let modes = Mode::heptatonic_modes()
+        .iter()
+        .map(|mode| mode.api_name())
+        .collect::<Vec<_>>();
     serde_wasm_bindgen::to_value(&modes).unwrap_or(JsValue::NULL)
 }
 
@@ -127,16 +128,7 @@ mod tests {
 
     #[wasm_bindgen_test::wasm_bindgen_test]
     fn test_available_modes_count() {
-        let modes = vec![
-            "ionian",
-            "dorian",
-            "phrygian",
-            "lydian",
-            "mixolydian",
-            "aeolian",
-            "locrian",
-        ];
-        assert_eq!(modes.len(), 7);
+        assert_eq!(Mode::heptatonic_modes().len(), 21);
     }
 
     #[wasm_bindgen_test::wasm_bindgen_test]
@@ -174,14 +166,67 @@ mod tests {
         .unwrap();
         assert_eq!(scale.direction, "descending");
         assert_eq!(
-            scale.notes.iter().map(|note| note.pitch.as_str()).collect::<Vec<_>>(),
+            scale
+                .notes
+                .iter()
+                .map(|note| note.pitch.as_str())
+                .collect::<Vec<_>>(),
             vec!["C", "Bb", "Ab", "G", "F", "Eb", "D", "C"]
         );
 
-        let scales: Vec<String> =
-            serde_wasm_bindgen::from_value(get_available_scales()).unwrap();
+        let scales: Vec<String> = serde_wasm_bindgen::from_value(get_available_scales()).unwrap();
         let modes: Vec<String> = serde_wasm_bindgen::from_value(get_available_modes()).unwrap();
         assert_eq!(scales.len(), 8);
-        assert_eq!(modes.len(), 7);
+        assert_eq!(modes.len(), 21);
+        assert!(modes.contains(&"phrygian_dominant".to_string()));
+        assert!(modes.contains(&"altered".to_string()));
+    }
+
+    #[wasm_bindgen_test::wasm_bindgen_test]
+    fn test_complete_minor_modes_and_invalid_input() {
+        let scale: WasmScale = serde_wasm_bindgen::from_value(generate_scale(
+            "C",
+            "harmonic_minor",
+            4,
+            Some("Spanish".to_string()),
+            true,
+        ))
+        .unwrap();
+        assert_eq!(scale.mode.as_deref(), Some("phrygian_dominant"));
+        assert_eq!(
+            scale
+                .notes
+                .iter()
+                .map(|note| note.pitch.as_str())
+                .collect::<Vec<_>>(),
+            vec!["C", "Db", "E", "F", "G", "Ab", "Bb", "C"]
+        );
+
+        let altered: WasmScale = serde_wasm_bindgen::from_value(generate_scale(
+            "C",
+            "melodic_minor",
+            4,
+            Some("super_locrian".to_string()),
+            false,
+        ))
+        .unwrap();
+        assert_eq!(altered.mode.as_deref(), Some("altered"));
+        assert_eq!(
+            altered
+                .notes
+                .iter()
+                .map(|note| note.pitch.as_str())
+                .collect::<Vec<_>>(),
+            vec!["C", "Bb", "Ab", "Gb", "Fb", "Eb", "Db", "C"]
+        );
+
+        assert!(generate_scale(
+            "C",
+            "melodic_minor",
+            4,
+            Some("not_a_mode".to_string()),
+            true,
+        )
+        .is_null());
     }
 }

--- a/tests/cli/test_cli.rs
+++ b/tests/cli/test_cli.rs
@@ -16,6 +16,9 @@ fn lists_every_supported_scale_and_chord() {
     let scales = rustmt(&["scale", "list"]);
     assert!(scales.status.success());
     assert!(stdout(&scales).contains("Whole Tone"));
+    assert!(stdout(&scales).contains("Phrygian Dominant"));
+    assert!(stdout(&scales).contains("Lydian Augmented"));
+    assert!(stdout(&scales).contains("Altered"));
 
     let chords = rustmt(&["chord", "list"]);
     assert!(chords.status.success());
@@ -41,16 +44,39 @@ fn prints_reference_scales_and_chords() {
 fn prints_non_chord_slash_bass_first() {
     let chord = rustmt(&["chord", "C/Fs"]);
     assert!(chord.status.success());
-    assert_eq!(
-        stdout(&chord),
-        "Notes:\n  1: F#\n  2: C\n  3: E\n  4: G\n"
-    );
+    assert_eq!(stdout(&chord), "Notes:\n  1: F#\n  2: C\n  3: E\n  4: G\n");
 }
 
 #[test]
 fn rejects_invalid_music_input() {
     assert!(!rustmt(&["chord", "C", "garbage"]).status.success());
     assert!(!rustmt(&["scale", "C", "garbage"]).status.success());
+}
+
+#[test]
+fn prints_complete_minor_modes_and_aliases() {
+    let phrygian_dominant = rustmt(&["scale", "C", "phrygian", "dominant"]);
+    assert!(phrygian_dominant.status.success());
+    assert_eq!(
+        stdout(&phrygian_dominant),
+        "Notes:\n  1: C\n  2: Db\n  3: E\n  4: F\n  5: G\n  6: Ab\n  7: Bb\n  8: C\n"
+    );
+
+    let altered = rustmt(&["scale", "C", "super", "locrian", "--descending"]);
+    assert!(altered.status.success());
+    assert_eq!(
+        stdout(&altered),
+        "Notes:\n  1: C\n  2: Bb\n  3: Ab\n  4: Gb\n  5: Fb\n  6: Eb\n  7: Db\n  8: C\n"
+    );
+
+    let unicode = rustmt(&["scale", "C", "dorian", "♭2"]);
+    assert!(unicode.status.success());
+
+    let invalid = rustmt(&["scale", "C", "not-a-mode"]);
+    assert!(!invalid.status.success());
+    let stderr = String::from_utf8(invalid.stderr).unwrap();
+    assert!(stderr.contains("Can't determine the mode"));
+    assert!(!stderr.contains("panicked"));
 }
 
 #[test]

--- a/tests/scale/test_minor_modes.rs
+++ b/tests/scale/test_minor_modes.rs
@@ -1,6 +1,6 @@
 extern crate rust_music_theory as theory;
 
-use theory::note::{Note, NoteLetter, Notes, Pitch};
+use theory::note::{NoteLetter, Notes, Pitch};
 use theory::scale::{Direction, Mode, Scale, ScaleType};
 
 fn pitches(scale: &Scale) -> Vec<String> {
@@ -168,12 +168,271 @@ fn harmonic_minor_modes_descend_through_the_same_pitch_collection() {
     }
 }
 
-#[allow(dead_code)]
-fn assert_notes_are_strictly_ordered(notes: &[Note], direction: Direction) {
-    for pair in notes.windows(2) {
-        match direction {
-            Direction::Ascending => assert!(pair[0].midi_pitch() < pair[1].midi_pitch()),
-            Direction::Descending => assert!(pair[0].midi_pitch() > pair[1].midi_pitch()),
+#[test]
+fn melodic_minor_modes_have_reference_formulas_and_spellings() {
+    let cases = [
+        (
+            Mode::MelodicMinor,
+            vec![2, 1, 2, 2, 2, 2, 1],
+            vec!["C", "D", "Eb", "F", "G", "A", "B", "C"],
+        ),
+        (
+            Mode::DorianFlat2,
+            vec![1, 2, 2, 2, 2, 1, 2],
+            vec!["C", "Db", "Eb", "F", "G", "A", "Bb", "C"],
+        ),
+        (
+            Mode::LydianAugmented,
+            vec![2, 2, 2, 2, 1, 2, 1],
+            vec!["C", "D", "E", "F#", "G#", "A", "B", "C"],
+        ),
+        (
+            Mode::LydianDominant,
+            vec![2, 2, 2, 1, 2, 1, 2],
+            vec!["C", "D", "E", "F#", "G", "A", "Bb", "C"],
+        ),
+        (
+            Mode::MixolydianFlat6,
+            vec![2, 2, 1, 2, 1, 2, 2],
+            vec!["C", "D", "E", "F", "G", "Ab", "Bb", "C"],
+        ),
+        (
+            Mode::LocrianSharp2,
+            vec![2, 1, 2, 1, 2, 2, 2],
+            vec!["C", "D", "Eb", "F", "Gb", "Ab", "Bb", "C"],
+        ),
+        (
+            Mode::Altered,
+            vec![1, 2, 1, 2, 2, 2, 2],
+            vec!["C", "Db", "Eb", "Fb", "Gb", "Ab", "Bb", "C"],
+        ),
+    ];
+
+    for (mode, expected_steps, expected_pitches) in cases {
+        let scale = Scale::new(
+            ScaleType::MelodicMinor,
+            Pitch::new(NoteLetter::C, 0),
+            4,
+            Some(mode),
+            Direction::Ascending,
+        )
+        .unwrap();
+        assert_eq!(
+            steps(&scale),
+            expected_steps,
+            "wrong formula for {:?}",
+            mode
+        );
+        assert_eq!(
+            pitches(&scale),
+            expected_pitches,
+            "wrong spelling for {:?}",
+            mode
+        );
+    }
+}
+
+#[test]
+fn melodic_minor_metadata_and_aliases_are_normalized() {
+    let cases = [
+        (Mode::DorianFlat2, "Dorian b2", "dorian_flat_2"),
+        (
+            Mode::LydianAugmented,
+            "Lydian Augmented",
+            "lydian_augmented",
+        ),
+        (Mode::LydianDominant, "Lydian Dominant", "lydian_dominant"),
+        (Mode::MixolydianFlat6, "Mixolydian b6", "mixolydian_flat_6"),
+        (Mode::LocrianSharp2, "Locrian #2", "locrian_sharp_2"),
+        (Mode::Altered, "Altered", "altered"),
+    ];
+
+    for (mode, canonical, api) in cases {
+        assert_eq!(mode.scale_type(), ScaleType::MelodicMinor);
+        assert_eq!(mode.canonical_name(), canonical);
+        assert_eq!(mode.api_name(), api);
+        assert_eq!(api.parse::<Mode>().unwrap(), mode);
+        assert_eq!(canonical.parse::<Mode>().unwrap(), mode);
+    }
+
+    for (alias, expected) in [
+        ("Dorian ♭2", Mode::DorianFlat2),
+        ("Phrygian sharp 6", Mode::DorianFlat2),
+        ("Lydian ♯5", Mode::LydianAugmented),
+        ("Overtone", Mode::LydianDominant),
+        ("Hindu", Mode::MixolydianFlat6),
+        ("Half-Diminished", Mode::LocrianSharp2),
+        ("diminished_whole_tone", Mode::Altered),
+    ] {
+        assert_eq!(alias.parse::<Mode>().unwrap(), expected, "alias {alias}");
+    }
+}
+
+#[test]
+fn classical_base_descent_and_jazz_derived_modes_are_distinct() {
+    let base = Scale::new(
+        ScaleType::MelodicMinor,
+        Pitch::new(NoteLetter::C, 0),
+        4,
+        Some(Mode::MelodicMinor),
+        Direction::Descending,
+    )
+    .unwrap();
+    assert_eq!(
+        pitches(&base),
+        vec!["C", "Bb", "Ab", "G", "F", "Eb", "D", "C"]
+    );
+
+    for mode in [
+        Mode::DorianFlat2,
+        Mode::LydianAugmented,
+        Mode::LydianDominant,
+        Mode::MixolydianFlat6,
+        Mode::LocrianSharp2,
+        Mode::Altered,
+    ] {
+        let ascending = Scale::new(
+            ScaleType::MelodicMinor,
+            Pitch::new(NoteLetter::C, 0),
+            4,
+            Some(mode),
+            Direction::Ascending,
+        )
+        .unwrap();
+        let descending = Scale::new(
+            ScaleType::MelodicMinor,
+            Pitch::new(NoteLetter::C, 0),
+            4,
+            Some(mode),
+            Direction::Descending,
+        )
+        .unwrap();
+        let mut ascending_classes = ascending
+            .notes()
+            .into_iter()
+            .take(7)
+            .map(|note| note.pitch.into_u8())
+            .collect::<Vec<_>>();
+        let mut descending_classes = descending
+            .notes()
+            .into_iter()
+            .take(7)
+            .map(|note| note.pitch.into_u8())
+            .collect::<Vec<_>>();
+        ascending_classes.sort_unstable();
+        descending_classes.sort_unstable();
+        assert_eq!(ascending_classes, descending_classes, "mode {:?}", mode);
+    }
+}
+
+#[test]
+fn incompatible_mode_families_return_a_structured_error() {
+    let error = Scale::new(
+        ScaleType::Diatonic,
+        Pitch::new(NoteLetter::C, 0),
+        4,
+        Some(Mode::Altered),
+        Direction::Ascending,
+    )
+    .unwrap_err();
+    assert_eq!(
+        error,
+        theory::scale::ScaleError::IncompatibleMode {
+            scale_type: ScaleType::Diatonic,
+            mode: Mode::Altered,
         }
+    );
+    assert_eq!(
+        error.to_string(),
+        "Mode Altered belongs to MelodicMinor, not Diatonic"
+    );
+}
+
+#[test]
+fn every_minor_mode_preserves_letters_octaves_and_midi_ordering() {
+    let modes = [
+        Mode::HarmonicMinor,
+        Mode::LocrianNatural6,
+        Mode::IonianSharp5,
+        Mode::DorianSharp4,
+        Mode::PhrygianDominant,
+        Mode::LydianSharp2,
+        Mode::UltraLocrian,
+        Mode::MelodicMinor,
+        Mode::DorianFlat2,
+        Mode::LydianAugmented,
+        Mode::LydianDominant,
+        Mode::MixolydianFlat6,
+        Mode::LocrianSharp2,
+        Mode::Altered,
+    ];
+    let roots = [
+        Pitch::new(NoteLetter::C, 0),
+        Pitch::new(NoteLetter::F, 1),
+        Pitch::new(NoteLetter::B, -1),
+        Pitch::new(NoteLetter::C, 2),
+        Pitch::new(NoteLetter::F, -2),
+    ];
+
+    for mode in modes {
+        for root in roots {
+            for direction in [Direction::Ascending, Direction::Descending] {
+                let scale = Scale::new(mode.scale_type(), root, 4, Some(mode), direction).unwrap();
+                let notes = scale.notes();
+                let mut letters = notes[..7]
+                    .iter()
+                    .map(|note| note.pitch.letter as u8)
+                    .collect::<Vec<_>>();
+                letters.sort_unstable();
+                letters.dedup();
+                assert_eq!(letters.len(), 7, "letters for {:?} from {:?}", mode, root);
+                for pair in notes.windows(2) {
+                    let ordered = match direction {
+                        Direction::Ascending => pair[0].midi_pitch() < pair[1].midi_pitch(),
+                        Direction::Descending => pair[0].midi_pitch() > pair[1].midi_pitch(),
+                    };
+                    assert!(
+                        ordered,
+                        "MIDI order for {:?} from {:?} {:?}: {:?}",
+                        mode, root, direction, notes
+                    );
+                }
+            }
+        }
+    }
+}
+
+#[test]
+fn all_mode_names_are_unique_and_round_trip() {
+    let modes = [
+        Mode::Ionian,
+        Mode::Dorian,
+        Mode::Phrygian,
+        Mode::Lydian,
+        Mode::Mixolydian,
+        Mode::Aeolian,
+        Mode::Locrian,
+        Mode::HarmonicMinor,
+        Mode::LocrianNatural6,
+        Mode::IonianSharp5,
+        Mode::DorianSharp4,
+        Mode::PhrygianDominant,
+        Mode::LydianSharp2,
+        Mode::UltraLocrian,
+        Mode::MelodicMinor,
+        Mode::DorianFlat2,
+        Mode::LydianAugmented,
+        Mode::LydianDominant,
+        Mode::MixolydianFlat6,
+        Mode::LocrianSharp2,
+        Mode::Altered,
+    ];
+    let mut canonical = std::collections::HashSet::new();
+    let mut api = std::collections::HashSet::new();
+    for mode in modes {
+        assert!(canonical.insert(mode.canonical_name()));
+        assert!(api.insert(mode.api_name()));
+        assert_eq!(mode.canonical_name().parse::<Mode>().unwrap(), mode);
+        assert_eq!(mode.api_name().parse::<Mode>().unwrap(), mode);
     }
 }

--- a/tests/scale/test_minor_modes.rs
+++ b/tests/scale/test_minor_modes.rs
@@ -1,0 +1,179 @@
+extern crate rust_music_theory as theory;
+
+use theory::note::{Note, NoteLetter, Notes, Pitch};
+use theory::scale::{Direction, Mode, Scale, ScaleType};
+
+fn pitches(scale: &Scale) -> Vec<String> {
+    scale
+        .notes()
+        .iter()
+        .map(|note| note.pitch.to_string())
+        .collect()
+}
+
+fn steps(scale: &Scale) -> Vec<u8> {
+    scale
+        .intervals
+        .iter()
+        .map(|interval| interval.semitone_count)
+        .collect()
+}
+
+#[test]
+fn harmonic_minor_modes_have_reference_formulas_and_spellings() {
+    let cases = [
+        (
+            Mode::HarmonicMinor,
+            vec![2, 1, 2, 2, 1, 3, 1],
+            vec!["C", "D", "Eb", "F", "G", "Ab", "B", "C"],
+        ),
+        (
+            Mode::LocrianNatural6,
+            vec![1, 2, 2, 1, 3, 1, 2],
+            vec!["C", "Db", "Eb", "F", "Gb", "A", "Bb", "C"],
+        ),
+        (
+            Mode::IonianSharp5,
+            vec![2, 2, 1, 3, 1, 2, 1],
+            vec!["C", "D", "E", "F", "G#", "A", "B", "C"],
+        ),
+        (
+            Mode::DorianSharp4,
+            vec![2, 1, 3, 1, 2, 1, 2],
+            vec!["C", "D", "Eb", "F#", "G", "A", "Bb", "C"],
+        ),
+        (
+            Mode::PhrygianDominant,
+            vec![1, 3, 1, 2, 1, 2, 2],
+            vec!["C", "Db", "E", "F", "G", "Ab", "Bb", "C"],
+        ),
+        (
+            Mode::LydianSharp2,
+            vec![3, 1, 2, 1, 2, 2, 1],
+            vec!["C", "D#", "E", "F#", "G", "A", "B", "C"],
+        ),
+        (
+            Mode::UltraLocrian,
+            vec![1, 2, 1, 2, 2, 1, 3],
+            vec!["C", "Db", "Eb", "Fb", "Gb", "Ab", "Bbb", "C"],
+        ),
+    ];
+
+    for (mode, expected_steps, expected_pitches) in cases {
+        let scale = Scale::new(
+            ScaleType::HarmonicMinor,
+            Pitch::new(NoteLetter::C, 0),
+            4,
+            Some(mode),
+            Direction::Ascending,
+        )
+        .unwrap();
+        assert_eq!(
+            steps(&scale),
+            expected_steps,
+            "wrong formula for {:?}",
+            mode
+        );
+        assert_eq!(
+            pitches(&scale),
+            expected_pitches,
+            "wrong spelling for {:?}",
+            mode
+        );
+    }
+}
+
+#[test]
+fn harmonic_minor_metadata_and_aliases_are_normalized() {
+    let cases = [
+        (
+            Mode::LocrianNatural6,
+            "Locrian natural 6",
+            "locrian_natural_6",
+        ),
+        (Mode::IonianSharp5, "Ionian #5", "ionian_sharp_5"),
+        (Mode::DorianSharp4, "Dorian #4", "dorian_sharp_4"),
+        (
+            Mode::PhrygianDominant,
+            "Phrygian Dominant",
+            "phrygian_dominant",
+        ),
+        (Mode::LydianSharp2, "Lydian #2", "lydian_sharp_2"),
+        (Mode::UltraLocrian, "Ultralocrian", "ultralocrian"),
+    ];
+
+    for (mode, canonical, api) in cases {
+        assert_eq!(mode.scale_type(), ScaleType::HarmonicMinor);
+        assert_eq!(mode.canonical_name(), canonical);
+        assert_eq!(mode.api_name(), api);
+        assert_eq!(api.parse::<Mode>().unwrap(), mode);
+        assert_eq!(canonical.parse::<Mode>().unwrap(), mode);
+    }
+
+    for (alias, expected) in [
+        ("Locrian ♮ 6", Mode::LocrianNatural6),
+        ("major sharp 5", Mode::IonianSharp5),
+        ("Ukrainian-Dorian", Mode::DorianSharp4),
+        ("Spanish", Mode::PhrygianDominant),
+        ("Lydian ♯9", Mode::LydianSharp2),
+        ("super_locrian diminished", Mode::UltraLocrian),
+    ] {
+        assert_eq!(alias.parse::<Mode>().unwrap(), expected, "alias {alias}");
+    }
+}
+
+#[test]
+fn harmonic_minor_modes_descend_through_the_same_pitch_collection() {
+    for mode in [
+        Mode::HarmonicMinor,
+        Mode::LocrianNatural6,
+        Mode::IonianSharp5,
+        Mode::DorianSharp4,
+        Mode::PhrygianDominant,
+        Mode::LydianSharp2,
+        Mode::UltraLocrian,
+    ] {
+        let ascending = Scale::new(
+            ScaleType::HarmonicMinor,
+            Pitch::new(NoteLetter::C, 0),
+            4,
+            Some(mode),
+            Direction::Ascending,
+        )
+        .unwrap();
+        let descending = Scale::new(
+            ScaleType::HarmonicMinor,
+            Pitch::new(NoteLetter::C, 0),
+            4,
+            Some(mode),
+            Direction::Descending,
+        )
+        .unwrap();
+
+        let mut ascending_classes = ascending
+            .notes()
+            .into_iter()
+            .take(7)
+            .map(|note| note.pitch.into_u8())
+            .collect::<Vec<_>>();
+        let mut descending_classes = descending
+            .notes()
+            .into_iter()
+            .take(7)
+            .map(|note| note.pitch.into_u8())
+            .collect::<Vec<_>>();
+        ascending_classes.sort_unstable();
+        descending_classes.sort_unstable();
+        assert_eq!(ascending_classes, descending_classes, "mode {:?}", mode);
+    }
+}
+
+#[allow(dead_code)]
+fn assert_notes_are_strictly_ordered(notes: &[Note], direction: Direction) {
+    for pair in notes.windows(2) {
+        match direction {
+            Direction::Ascending => assert!(pair[0].midi_pitch() < pair[1].midi_pitch()),
+            Direction::Descending => assert!(pair[0].midi_pitch() > pair[1].midi_pitch()),
+        }
+    }
+}

--- a/tests/tests.rs
+++ b/tests/tests.rs
@@ -15,6 +15,7 @@ mod scale {
     mod test_scale;
     mod test_exotic_scales;
     mod test_additional_scales;
+    mod test_minor_modes;
 }
 
 mod note {

--- a/tests/theory/test_reference_theory.rs
+++ b/tests/theory/test_reference_theory.rs
@@ -199,7 +199,10 @@ fn every_supported_chord_formula_is_transposed_and_spelled_by_chord_member() {
             }
 
             let recognized = Chord::from_interval(root, adjacent_intervals).unwrap();
-            assert_eq!((recognized.quality(), recognized.number()), (quality, number));
+            assert_eq!(
+                (recognized.quality(), recognized.number()),
+                (quality, number)
+            );
         }
     }
 }
@@ -506,7 +509,19 @@ fn scale_type_mapping_is_exhaustive() {
         (Mode::Aeolian, ScaleType::Diatonic),
         (Mode::Locrian, ScaleType::Diatonic),
         (Mode::HarmonicMinor, ScaleType::HarmonicMinor),
+        (Mode::LocrianNatural6, ScaleType::HarmonicMinor),
+        (Mode::IonianSharp5, ScaleType::HarmonicMinor),
+        (Mode::DorianSharp4, ScaleType::HarmonicMinor),
+        (Mode::PhrygianDominant, ScaleType::HarmonicMinor),
+        (Mode::LydianSharp2, ScaleType::HarmonicMinor),
+        (Mode::UltraLocrian, ScaleType::HarmonicMinor),
         (Mode::MelodicMinor, ScaleType::MelodicMinor),
+        (Mode::DorianFlat2, ScaleType::MelodicMinor),
+        (Mode::LydianAugmented, ScaleType::MelodicMinor),
+        (Mode::LydianDominant, ScaleType::MelodicMinor),
+        (Mode::MixolydianFlat6, ScaleType::MelodicMinor),
+        (Mode::LocrianSharp2, ScaleType::MelodicMinor),
+        (Mode::Altered, ScaleType::MelodicMinor),
         (Mode::PentatonicMajor, ScaleType::PentatonicMajor),
         (Mode::PentatonicMinor, ScaleType::PentatonicMinor),
         (Mode::Blues, ScaleType::Blues),


### PR DESCRIPTION
## Summary

- add all twelve missing rotations of harmonic and melodic minor
- centralize mode families, rotations, canonical names, API identifiers, and aliases
- validate incompatible scale family and mode combinations
- preserve classical melodic-minor descent while derived modes use jazz collections
- expose all 21 heptatonic modes through Rust, CLI, and WASM
- mark arbitrary accidentals and complete minor modes finished in the roadmap

## User and developer impact

Applications can now generate modes such as Phrygian dominant, Lydian augmented, Lydian dominant, Altered, and Ultralocrian with correct theoretical spelling. Mode input accepts established aliases, Unicode accidentals, human-readable names, and stable snake-case identifiers.

## Additional fix

The expanded ordering tests found that scale notes could retain an octave chosen for a temporary enharmonic spelling, producing values such as B5 instead of B4 in C harmonic minor. Scale octaves are now synchronized after final theoretical spelling.

## Validation

- default native matrix: 206 passed
- MIDI matrix: 248 passed
- MIDI playback matrix: 276 passed, 8 hardware-dependent ignored
- `wasm-pack test --node`: 26 passed
- Rustdoc: 2 passed, 2 ignored
- web WASM build, targeted formatting, and diff checks passed
